### PR TITLE
feat: add company management for super admin

### DIFF
--- a/apps/api/src/index.js
+++ b/apps/api/src/index.js
@@ -11,6 +11,7 @@ app.use(cors({ origin: process.env.CLIENT_ORIGIN, credentials: true }));
 app.get('/', (req, res) => res.json({ ok: true }));
 app.use('/auth', require('./routes/auth'));
 app.use('/seed', require('./routes/seed'));
+app.use('/companies', require('./routes/companies'));
 
 connectDB().then(() => {
   const port = process.env.PORT || 4000;

--- a/apps/api/src/models/Company.js
+++ b/apps/api/src/models/Company.js
@@ -1,0 +1,11 @@
+const mongoose = require('mongoose');
+
+const CompanySchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true },
+    admin: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true }
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('Company', CompanySchema);

--- a/apps/api/src/routes/companies.js
+++ b/apps/api/src/routes/companies.js
@@ -1,0 +1,29 @@
+const router = require('express').Router();
+const bcrypt = require('bcryptjs');
+const { auth } = require('../middleware/auth');
+const Company = require('../models/Company');
+const User = require('../models/User');
+
+// Create company with an admin user
+router.post('/', auth, async (req, res) => {
+  if (req.user.primaryRole !== 'SUPERADMIN') return res.status(403).json({ error: 'Forbidden' });
+  const { companyName, adminName, adminEmail, adminPassword } = req.body;
+  if (!companyName || !adminName || !adminEmail || !adminPassword) {
+    return res.status(400).json({ error: 'Missing fields' });
+  }
+  let admin = await User.findOne({ email: adminEmail });
+  if (admin) return res.status(400).json({ error: 'Admin already exists' });
+  const passwordHash = await bcrypt.hash(adminPassword, 10);
+  admin = await User.create({ name: adminName, email: adminEmail, passwordHash, primaryRole: 'ADMIN', subRoles: [] });
+  const company = await Company.create({ name: companyName, admin: admin._id });
+  res.json({ company });
+});
+
+// List companies with admins
+router.get('/', auth, async (req, res) => {
+  if (req.user.primaryRole !== 'SUPERADMIN') return res.status(403).json({ error: 'Forbidden' });
+  const companies = await Company.find().populate('admin', 'name email');
+  res.json({ companies });
+});
+
+module.exports = router;

--- a/apps/web/src/pages/superadmin/Dashboard.tsx
+++ b/apps/web/src/pages/superadmin/Dashboard.tsx
@@ -1,8 +1,95 @@
+import { useEffect, useState, FormEvent } from 'react';
+import { api } from '../../lib/api';
+
+type Company = {
+  _id: string;
+  name: string;
+  admin: { name: string; email: string };
+};
+
 export default function SADash() {
+  const [companies, setCompanies] = useState<Company[]>([]);
+  const [companyName, setCompanyName] = useState('');
+  const [adminName, setAdminName] = useState('');
+  const [adminEmail, setAdminEmail] = useState('');
+  const [adminPassword, setAdminPassword] = useState('');
+
+  async function load() {
+    try {
+      const res = await api.get('/companies');
+      setCompanies(res.data.companies);
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function submit(e: FormEvent) {
+    e.preventDefault();
+    try {
+      await api.post('/companies', { companyName, adminName, adminEmail, adminPassword });
+      setCompanyName('');
+      setAdminName('');
+      setAdminEmail('');
+      setAdminPassword('');
+      load();
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
   return (
-    <div className="space-y-2">
-      <h2 className="text-2xl font-semibold">Superadmin Dashboard</h2>
-      <div className="text-sm">Manage tenants, admins, and global settings</div>
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h2 className="text-2xl font-semibold">Superadmin Dashboard</h2>
+        <div className="text-sm">Manage tenants, admins, and global settings</div>
+      </div>
+
+      <form onSubmit={submit} className="space-y-2 max-w-md">
+        <input
+          className="w-full border p-1"
+          placeholder="Company Name"
+          value={companyName}
+          onChange={e => setCompanyName(e.target.value)}
+        />
+        <input
+          className="w-full border p-1"
+          placeholder="Admin Name"
+          value={adminName}
+          onChange={e => setAdminName(e.target.value)}
+        />
+        <input
+          className="w-full border p-1"
+          placeholder="Admin Email"
+          type="email"
+          value={adminEmail}
+          onChange={e => setAdminEmail(e.target.value)}
+        />
+        <input
+          className="w-full border p-1"
+          placeholder="Admin Password"
+          type="password"
+          value={adminPassword}
+          onChange={e => setAdminPassword(e.target.value)}
+        />
+        <button className="px-4 py-1 bg-blue-500 text-white" type="submit">
+          Add Company
+        </button>
+      </form>
+
+      <div>
+        <h3 className="font-semibold mb-2">Companies</h3>
+        <ul className="space-y-1">
+          {companies.map(c => (
+            <li key={c._id} className="text-sm">
+              {c.name} – {c.admin?.name} ({c.admin?.email})
+            </li>
+          ))}
+        </ul>
+      </div>
     </div>
   );
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -10,7 +10,8 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "strict": true
+    "strict": true,
+    "types": ["vite/client"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- add Company schema and company routes for super admins
- allow super admins to create companies with admins and list them on dashboard
- include Vite types in tsconfig for successful builds

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build -w apps/web`


------
https://chatgpt.com/codex/tasks/task_e_68ac25095b34832b934090fcacd5d41f