### PR TITLE
feat: allow admins to manage company users

### DIFF
--- a/apps/api/src/models/User.js
+++ b/apps/api/src/models/User.js
@@ -6,7 +6,8 @@ const UserSchema = new mongoose.Schema(
     email: { type: String, required: true, unique: true, index: true },
     passwordHash: { type: String, required: true },
     primaryRole: { type: String, enum: ['SUPERADMIN', 'ADMIN', 'USER'], default: 'USER' },
-    subRoles: { type: [String], default: [] }
+    subRoles: { type: [String], default: [] },
+    company: { type: mongoose.Schema.Types.ObjectId, ref: 'Company' }
   },
   { timestamps: true }
 );

--- a/apps/api/src/routes/auth.js
+++ b/apps/api/src/routes/auth.js
@@ -10,7 +10,14 @@ router.post('/login', async (req, res) => {
   if (!user) return res.status(400).json({ error: 'Invalid credentials' });
   const ok = await bcrypt.compare(password, user.passwordHash);
   if (!ok) return res.status(400).json({ error: 'Invalid credentials' });
-  const payload = { id: user._id.toString(), name: user.name, email: user.email, primaryRole: user.primaryRole, subRoles: user.subRoles };
+  const payload = {
+    id: user._id.toString(),
+    name: user.name,
+    email: user.email,
+    primaryRole: user.primaryRole,
+    subRoles: user.subRoles,
+    company: user.company
+  };
   const token = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '2h' });
   res.json({ token, user: payload });
 });
@@ -18,7 +25,14 @@ router.post('/login', async (req, res) => {
 router.get('/me', auth, async (req, res) => {
   const user = await User.findById(req.user.id).lean();
   if (!user) return res.status(404).json({ error: 'Not found' });
-  const payload = { id: user._id.toString(), name: user.name, email: user.email, primaryRole: user.primaryRole, subRoles: user.subRoles };
+  const payload = {
+    id: user._id.toString(),
+    name: user.name,
+    email: user.email,
+    primaryRole: user.primaryRole,
+    subRoles: user.subRoles,
+    company: user.company
+  };
   res.json({ user: payload });
 });
 

--- a/apps/api/src/routes/companies.js
+++ b/apps/api/src/routes/companies.js
@@ -16,6 +16,8 @@ router.post('/', auth, async (req, res) => {
   const passwordHash = await bcrypt.hash(adminPassword, 10);
   admin = await User.create({ name: adminName, email: adminEmail, passwordHash, primaryRole: 'ADMIN', subRoles: [] });
   const company = await Company.create({ name: companyName, admin: admin._id });
+  admin.company = company._id;
+  await admin.save();
   res.json({ company });
 });
 
@@ -24,6 +26,29 @@ router.get('/', auth, async (req, res) => {
   if (req.user.primaryRole !== 'SUPERADMIN') return res.status(403).json({ error: 'Forbidden' });
   const companies = await Company.find().populate('admin', 'name email');
   res.json({ companies });
+});
+
+// Admin: create user in their company
+router.post('/users', auth, async (req, res) => {
+  if (!['ADMIN', 'SUPERADMIN'].includes(req.user.primaryRole)) return res.status(403).json({ error: 'Forbidden' });
+  const { name, email, password, role } = req.body;
+  if (!name || !email || !password || !role) return res.status(400).json({ error: 'Missing fields' });
+  const company = await Company.findOne({ admin: req.user.id });
+  if (!company) return res.status(400).json({ error: 'Company not found' });
+  let existing = await User.findOne({ email });
+  if (existing) return res.status(400).json({ error: 'User already exists' });
+  const passwordHash = await bcrypt.hash(password, 10);
+  const user = await User.create({ name, email, passwordHash, primaryRole: 'USER', subRoles: [role], company: company._id });
+  res.json({ user: { id: user._id, name: user.name, email: user.email, subRoles: user.subRoles } });
+});
+
+// Admin: list users in their company
+router.get('/users', auth, async (req, res) => {
+  if (!['ADMIN', 'SUPERADMIN'].includes(req.user.primaryRole)) return res.status(403).json({ error: 'Forbidden' });
+  const company = await Company.findOne({ admin: req.user.id });
+  if (!company) return res.status(400).json({ error: 'Company not found' });
+  const users = await User.find({ company: company._id }).select('name email subRoles').lean();
+  res.json({ users: users.map(u => ({ id: u._id, name: u.name, email: u.email, subRoles: u.subRoles })) });
 });
 
 module.exports = router;

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,5 +1,5 @@
 export type PrimaryRole = 'SUPERADMIN' | 'ADMIN' | 'USER';
-export type SubRole = 'hr' | 'manager' | 'plain';
+export type SubRole = 'hr' | 'manager' | 'developer' | 'plain';
 
 export type User = {
   id: string;
@@ -7,6 +7,7 @@ export type User = {
   email: string;
   primaryRole: PrimaryRole;
   subRoles: SubRole[];
+  company?: string;
 };
 
 export function setAuth(token: string, user: User) {

--- a/apps/web/src/pages/admin/Dashboard.tsx
+++ b/apps/web/src/pages/admin/Dashboard.tsx
@@ -1,8 +1,105 @@
+import { useEffect, useState, FormEvent } from 'react';
+import { api } from '../../lib/api';
+
+interface CompanyUser {
+  id: string;
+  name: string;
+  email: string;
+  subRoles: string[];
+}
+
 export default function AdminDash() {
+  const [users, setUsers] = useState<CompanyUser[]>([]);
+  const [form, setForm] = useState({ name: '', email: '', password: '', role: 'hr' });
+
+  async function load() {
+    try {
+      const res = await api.get('/companies/users');
+      setUsers(res.data.users);
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function submit(e: FormEvent) {
+    e.preventDefault();
+    try {
+      await api.post('/companies/users', form);
+      setForm({ name: '', email: '', password: '', role: 'hr' });
+      load();
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
   return (
-    <div className="space-y-2">
-      <h2 className="text-2xl font-semibold">Admin Dashboard</h2>
-      <div className="text-sm">Company settings, departments, roles</div>
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h2 className="text-2xl font-semibold">Admin Dashboard</h2>
+        <div className="text-sm">Company settings, departments, roles</div>
+      </div>
+
+      <form onSubmit={submit} className="space-y-2 max-w-md">
+        <input
+          className="w-full border p-1"
+          placeholder="Name"
+          value={form.name}
+          onChange={e => setForm({ ...form, name: e.target.value })}
+        />
+        <input
+          className="w-full border p-1"
+          placeholder="Email"
+          type="email"
+          value={form.email}
+          onChange={e => setForm({ ...form, email: e.target.value })}
+        />
+        <input
+          className="w-full border p-1"
+          placeholder="Password"
+          type="password"
+          value={form.password}
+          onChange={e => setForm({ ...form, password: e.target.value })}
+        />
+        <select
+          className="w-full border p-1"
+          value={form.role}
+          onChange={e => setForm({ ...form, role: e.target.value })}
+        >
+          <option value="hr">HR</option>
+          <option value="manager">Manager</option>
+          <option value="developer">Developer</option>
+        </select>
+        <button className="px-4 py-1 bg-blue-500 text-white" type="submit">
+          Add User
+        </button>
+      </form>
+
+      <div>
+        <h3 className="font-semibold mb-2">Company Users</h3>
+        <table className="w-full text-sm border">
+          <thead>
+            <tr className="border-b">
+              <th className="p-1 text-left">Name</th>
+              <th className="p-1 text-left">Email</th>
+              <th className="p-1 text-left">Role</th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.map(u => (
+              <tr key={u.id} className="border-b">
+                <td className="p-1">{u.name}</td>
+                <td className="p-1">{u.email}</td>
+                <td className="p-1">{u.subRoles[0]}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- track company on user model and include in auth payloads
- add API endpoints so admins can create and list company users with roles
- extend frontend types and admin dashboard to manage HR, manager, and developer users

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ac28bedba8832b8dd1f4a22de5a7df