### PR TITLE
Add attendance punch in/out with live timer

### DIFF
--- a/apps/api/src/index.js
+++ b/apps/api/src/index.js
@@ -12,6 +12,7 @@ app.get('/', (req, res) => res.json({ ok: true }));
 app.use('/auth', require('./routes/auth'));
 app.use('/seed', require('./routes/seed'));
 app.use('/companies', require('./routes/companies'));
+app.use('/attendance', require('./routes/attendance'));
 
 connectDB().then(() => {
   const port = process.env.PORT || 4000;

--- a/apps/api/src/models/Attendance.js
+++ b/apps/api/src/models/Attendance.js
@@ -1,0 +1,12 @@
+const mongoose = require('mongoose');
+
+const AttendanceSchema = new mongoose.Schema({
+  user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  date: { type: Date, required: true },
+  firstPunchIn: { type: Date },
+  lastPunchOut: { type: Date }
+});
+
+AttendanceSchema.index({ user: 1, date: 1 }, { unique: true });
+
+module.exports = mongoose.model('Attendance', AttendanceSchema);

--- a/apps/api/src/routes/attendance.js
+++ b/apps/api/src/routes/attendance.js
@@ -1,0 +1,52 @@
+const router = require('express').Router();
+const { auth } = require('../middleware/auth');
+const Attendance = require('../models/Attendance');
+const User = require('../models/User');
+
+function startOfDay(d) {
+  const x = new Date(d);
+  x.setHours(0, 0, 0, 0);
+  return x;
+}
+
+router.post('/punch', auth, async (req, res) => {
+  const { action } = req.body;
+  if (!['in', 'out'].includes(action)) return res.status(400).json({ error: 'Invalid action' });
+
+  const today = startOfDay(new Date());
+  let record = await Attendance.findOne({ user: req.user.id, date: today });
+  if (!record) {
+    record = await Attendance.create({ user: req.user.id, date: today, firstPunchIn: new Date() });
+    return res.json({ attendance: record });
+  }
+
+  if (action === 'in') {
+    if (!record.firstPunchIn) record.firstPunchIn = new Date();
+  } else {
+    record.lastPunchOut = new Date();
+  }
+  await record.save();
+  res.json({ attendance: record });
+});
+
+router.get('/today', auth, async (req, res) => {
+  const today = startOfDay(new Date());
+  const record = await Attendance.findOne({ user: req.user.id, date: today });
+  res.json({ attendance: record });
+});
+
+router.get('/company/today', auth, async (req, res) => {
+  if (!['ADMIN', 'SUPERADMIN'].includes(req.user.primaryRole)) return res.status(403).json({ error: 'Forbidden' });
+  const today = startOfDay(new Date());
+  const users = await User.find({ company: req.user.company }).select('_id name');
+  const records = await Attendance.find({ user: { $in: users.map(u => u._id) }, date: today }).populate('user', 'name');
+  res.json({
+    attendance: records.map(r => ({
+      user: { id: r.user._id, name: r.user.name },
+      firstPunchIn: r.firstPunchIn,
+      lastPunchOut: r.lastPunchOut
+    }))
+  });
+});
+
+module.exports = router;

--- a/apps/web/src/pages/admin/Dashboard.tsx
+++ b/apps/web/src/pages/admin/Dashboard.tsx
@@ -8,14 +8,23 @@ interface CompanyUser {
   subRoles: string[];
 }
 
+interface AttendanceRecord {
+  user: { id: string; name: string };
+  firstPunchIn?: string;
+  lastPunchOut?: string;
+}
+
 export default function AdminDash() {
   const [users, setUsers] = useState<CompanyUser[]>([]);
   const [form, setForm] = useState({ name: '', email: '', password: '', role: 'hr' });
+  const [attendance, setAttendance] = useState<AttendanceRecord[]>([]);
 
   async function load() {
     try {
       const res = await api.get('/companies/users');
       setUsers(res.data.users);
+      const att = await api.get('/attendance/company/today');
+      setAttendance(att.data.attendance);
     } catch (e) {
       console.error(e);
     }
@@ -94,6 +103,36 @@ export default function AdminDash() {
                 <td className="p-1">{u.name}</td>
                 <td className="p-1">{u.email}</td>
                 <td className="p-1">{u.subRoles[0]}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div>
+        <h3 className="font-semibold mb-2">Today's Attendance</h3>
+        <table className="w-full text-sm border">
+          <thead>
+            <tr className="border-b">
+              <th className="p-1 text-left">Name</th>
+              <th className="p-1 text-left">First In</th>
+              <th className="p-1 text-left">Last Out</th>
+            </tr>
+          </thead>
+          <tbody>
+            {attendance.map(a => (
+              <tr key={a.user.id} className="border-b">
+                <td className="p-1">{a.user.name}</td>
+                <td className="p-1">
+                  {a.firstPunchIn
+                    ? new Date(a.firstPunchIn).toLocaleTimeString()
+                    : '-'}
+                </td>
+                <td className="p-1">
+                  {a.lastPunchOut
+                    ? new Date(a.lastPunchOut).toLocaleTimeString()
+                    : '-'}
+                </td>
               </tr>
             ))}
           </tbody>

--- a/apps/web/src/pages/user/Dashboard.tsx
+++ b/apps/web/src/pages/user/Dashboard.tsx
@@ -1,13 +1,89 @@
+import { useEffect, useState } from 'react';
+import { api } from '../../lib/api';
 import RoleGuard from '../../components/RoleGuard';
 
+interface Attendance {
+  firstPunchIn?: string;
+  lastPunchOut?: string;
+}
+
+function format(ms: number) {
+  const total = Math.floor(ms / 1000);
+  const h = Math.floor(total / 3600)
+    .toString()
+    .padStart(2, '0');
+  const m = Math.floor((total % 3600) / 60)
+    .toString()
+    .padStart(2, '0');
+  const s = Math.floor(total % 60)
+    .toString()
+    .padStart(2, '0');
+  return `${h}:${m}:${s}`;
+}
+
 export default function UserDash() {
+  const [attendance, setAttendance] = useState<Attendance | null>(null);
+  const [elapsed, setElapsed] = useState(0);
+
+  async function load() {
+    const res = await api.get('/attendance/today');
+    setAttendance(res.data.attendance);
+  }
+
+  async function punch(action: 'in' | 'out') {
+    await api.post('/attendance/punch', { action });
+    load();
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  useEffect(() => {
+    if (attendance?.firstPunchIn && !attendance.lastPunchOut) {
+      const interval = setInterval(() => {
+        setElapsed(Date.now() - new Date(attendance.firstPunchIn!).getTime());
+      }, 1000);
+      return () => clearInterval(interval);
+    } else if (attendance?.firstPunchIn && attendance.lastPunchOut) {
+      setElapsed(
+        new Date(attendance.lastPunchOut).getTime() -
+          new Date(attendance.firstPunchIn).getTime()
+      );
+    } else {
+      setElapsed(0);
+    }
+  }, [attendance]);
+
   return (
     <div className="space-y-4">
       <h2 className="text-2xl font-semibold">User Area</h2>
+      <div className="p-4 border rounded space-y-2">
+        <div>Time worked today: {format(elapsed)}</div>
+        {!attendance?.firstPunchIn || attendance.lastPunchOut ? (
+          <button
+            className="px-4 py-1 bg-green-500 text-white"
+            onClick={() => punch('in')}
+          >
+            Punch In
+          </button>
+        ) : (
+          <button
+            className="px-4 py-1 bg-red-500 text-white"
+            onClick={() => punch('out')}
+          >
+            Punch Out
+          </button>
+        )}
+      </div>
       <div className="grid gap-4 grid-cols-1 md:grid-cols-2">
         <div className="p-4 border rounded">General</div>
-        <RoleGuard sub={["hr"]}><div className="p-4 border rounded">HR Panel</div></RoleGuard>
-        <RoleGuard sub={["manager"]}><div className="p-4 border rounded">Manager Panel</div></RoleGuard>
+        <RoleGuard sub={["hr"]}>
+          <div className="p-4 border rounded">HR Panel</div>
+        </RoleGuard>
+        <RoleGuard sub={["manager"]}>
+          <div className="p-4 border rounded">Manager Panel</div>
+        </RoleGuard>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- track daily attendance with new model and API routes for punch in/out
- show punch controls and live worked-time timer on user dashboard
- add admin view listing each user's first punch in and last punch out of the day

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build -w apps/web`


------
https://chatgpt.com/codex/tasks/task_e_68ac2b5f8b1c832b9d68d2b8b54ded6f