### PR TITLE
Add persistent attendance tracking and filter admins

### DIFF
--- a/apps/api/src/models/Attendance.js
+++ b/apps/api/src/models/Attendance.js
@@ -4,7 +4,9 @@ const AttendanceSchema = new mongoose.Schema({
   user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
   date: { type: Date, required: true },
   firstPunchIn: { type: Date },
-  lastPunchOut: { type: Date }
+  lastPunchOut: { type: Date },
+  lastPunchIn: { type: Date },
+  workedMs: { type: Number, default: 0 }
 });
 
 AttendanceSchema.index({ user: 1, date: 1 }, { unique: true });

--- a/apps/web/src/pages/user/Dashboard.tsx
+++ b/apps/web/src/pages/user/Dashboard.tsx
@@ -5,6 +5,8 @@ import RoleGuard from '../../components/RoleGuard';
 interface Attendance {
   firstPunchIn?: string;
   lastPunchOut?: string;
+  lastPunchIn?: string;
+  workedMs?: number;
 }
 
 function format(ms: number) {
@@ -40,16 +42,15 @@ export default function UserDash() {
   }, []);
 
   useEffect(() => {
-    if (attendance?.firstPunchIn && !attendance.lastPunchOut) {
+    if (attendance?.lastPunchIn) {
+      const start = new Date(attendance.lastPunchIn).getTime();
+      const base = attendance.workedMs || 0;
       const interval = setInterval(() => {
-        setElapsed(Date.now() - new Date(attendance.firstPunchIn!).getTime());
+        setElapsed(base + (Date.now() - start));
       }, 1000);
       return () => clearInterval(interval);
-    } else if (attendance?.firstPunchIn && attendance.lastPunchOut) {
-      setElapsed(
-        new Date(attendance.lastPunchOut).getTime() -
-          new Date(attendance.firstPunchIn).getTime()
-      );
+    } else if (attendance?.workedMs) {
+      setElapsed(attendance.workedMs);
     } else {
       setElapsed(0);
     }
@@ -60,7 +61,7 @@ export default function UserDash() {
       <h2 className="text-2xl font-semibold">User Area</h2>
       <div className="p-4 border rounded space-y-2">
         <div>Time worked today: {format(elapsed)}</div>
-        {!attendance?.firstPunchIn || attendance.lastPunchOut ? (
+        {!attendance?.lastPunchIn ? (
           <button
             className="px-4 py-1 bg-green-500 text-white"
             onClick={() => punch('in')}


### PR DESCRIPTION
## Summary
- Track active and total worked time in attendance records
- Exclude admin and superadmin accounts from company attendance listing
- Resume user timers across punch in/out cycles on the dashboard

## Testing
- `npm test --prefix apps/api` *(fails: Missing script "test")*
- `npm test --prefix apps/web` *(fails: Missing script "test")*
- `npm run lint --prefix apps/web` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68ac33076364832bb3d2ace898d189f7