### PR TITLE
Add role-specific navigation and pages

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -6,8 +6,16 @@ import SuperAdminLayout from './layouts/SuperAdminLayout';
 import AdminLayout from './layouts/AdminLayout';
 import UserLayout from './layouts/UserLayout';
 import SADash from './pages/superadmin/Dashboard';
+import CompanyList from './pages/superadmin/CompanyList';
+import AddCompany from './pages/superadmin/AddCompany';
+
 import AdminDash from './pages/admin/Dashboard';
+import AddUser from './pages/admin/AddUser';
+import UserList from './pages/admin/UserList';
+import AttendanceList from './pages/admin/AttendanceList';
+
 import UserDash from './pages/user/Dashboard';
+import AttendanceRecords from './pages/user/AttendanceRecords';
 
 export default function App() {
   return (
@@ -25,6 +33,8 @@ export default function App() {
         }
       >
         <Route index element={<SADash />} />
+        <Route path="companies" element={<CompanyList />} />
+        <Route path="companies/add" element={<AddCompany />} />
       </Route>
 
       <Route
@@ -38,6 +48,9 @@ export default function App() {
         }
       >
         <Route index element={<AdminDash />} />
+        <Route path="users/add" element={<AddUser />} />
+        <Route path="users" element={<UserList />} />
+        <Route path="attendances" element={<AttendanceList />} />
       </Route>
 
       <Route
@@ -51,6 +64,7 @@ export default function App() {
         }
       >
         <Route index element={<UserDash />} />
+        <Route path="attendance" element={<AttendanceRecords />} />
       </Route>
 
       <Route path="*" element={<Navigate to="/login" replace />} />

--- a/apps/web/src/layouts/AdminLayout.tsx
+++ b/apps/web/src/layouts/AdminLayout.tsx
@@ -4,19 +4,39 @@ import { clearAuth, getUser } from '../lib/auth';
 export default function AdminLayout() {
   const nav = useNavigate();
   const u = getUser();
+
+  const links = [
+    { to: '/admin', label: 'Dashboard' },
+    { to: '/admin/users/add', label: 'Add User' },
+    { to: '/admin/users', label: 'User List' },
+    { to: '/admin/attendances', label: 'Attendances' }
+  ];
+
   return (
-    <div className="min-h-screen bg-white">
-      <header className="flex items-center justify-between px-6 h-14 bg-blue-600 text-white">
-        <div className="font-bold">HRMS Admin</div>
-        <div className="flex items-center gap-4">
-          <span className="text-sm">{u?.name}</span>
-          <button onClick={() => { clearAuth(); nav('/login'); }} className="text-sm underline">Logout</button>
+    <div className="min-h-screen flex bg-white">
+      <aside className="w-56 bg-blue-700 text-white flex flex-col p-4">
+        <div className="font-bold mb-6">HRMS Admin</div>
+        <nav className="flex-1 space-y-2">
+          {links.map(l => (
+            <Link key={l.to} to={l.to} className="block hover:underline">
+              {l.label}
+            </Link>
+          ))}
+        </nav>
+        <div className="pt-4 border-t border-blue-600 text-sm">
+          <div className="mb-2">{u?.name}</div>
+          <button
+            onClick={() => {
+              clearAuth();
+              nav('/login');
+            }}
+            className="underline"
+          >
+            Logout
+          </button>
         </div>
-      </header>
-      <nav className="px-6 py-3 bg-blue-50 border-b">
-        <Link className="mr-4" to="/admin">Dashboard</Link>
-      </nav>
-      <main className="p-6">
+      </aside>
+      <main className="flex-1 p-6">
         <Outlet />
       </main>
     </div>

--- a/apps/web/src/layouts/SuperAdminLayout.tsx
+++ b/apps/web/src/layouts/SuperAdminLayout.tsx
@@ -4,19 +4,38 @@ import { clearAuth, getUser } from '../lib/auth';
 export default function SuperAdminLayout() {
   const nav = useNavigate();
   const u = getUser();
+
+  const links = [
+    { to: '/superadmin', label: 'Dashboard' },
+    { to: '/superadmin/companies', label: 'Companies' },
+    { to: '/superadmin/companies/add', label: 'Add Company' }
+  ];
+
   return (
-    <div className="min-h-screen bg-gray-50">
-      <header className="flex items-center justify-between px-6 h-14 bg-black text-white">
-        <div className="font-bold">HRMS Superadmin</div>
-        <div className="flex items-center gap-4">
-          <span className="text-sm">{u?.name}</span>
-          <button onClick={() => { clearAuth(); nav('/login'); }} className="text-sm underline">Logout</button>
+    <div className="min-h-screen flex bg-gray-50">
+      <aside className="w-56 bg-black text-white flex flex-col p-4">
+        <div className="font-bold mb-6">HRMS Superadmin</div>
+        <nav className="flex-1 space-y-2">
+          {links.map(l => (
+            <Link key={l.to} to={l.to} className="block hover:underline">
+              {l.label}
+            </Link>
+          ))}
+        </nav>
+        <div className="pt-4 border-t border-gray-700 text-sm">
+          <div className="mb-2">{u?.name}</div>
+          <button
+            onClick={() => {
+              clearAuth();
+              nav('/login');
+            }}
+            className="underline"
+          >
+            Logout
+          </button>
         </div>
-      </header>
-      <nav className="px-6 py-3 bg-gray-100 border-b">
-        <Link className="mr-4" to="/superadmin">Dashboard</Link>
-      </nav>
-      <main className="p-6">
+      </aside>
+      <main className="flex-1 p-6">
         <Outlet />
       </main>
     </div>

--- a/apps/web/src/layouts/UserLayout.tsx
+++ b/apps/web/src/layouts/UserLayout.tsx
@@ -4,19 +4,37 @@ import { clearAuth, getUser } from '../lib/auth';
 export default function UserLayout() {
   const nav = useNavigate();
   const u = getUser();
+
+  const links = [
+    { to: '/app', label: 'Dashboard' },
+    { to: '/app/attendance', label: 'Attendance' }
+  ];
+
   return (
-    <div className="min-h-screen bg-slate-50">
-      <header className="flex items-center justify-between px-6 h-14 bg-slate-900 text-white">
-        <div className="font-bold">HRMS</div>
-        <div className="flex items-center gap-3">
-          <div className="text-xs">{u?.subRoles.join(', ')}</div>
-          <button onClick={() => { clearAuth(); nav('/login'); }} className="text-sm underline">Logout</button>
+    <div className="min-h-screen flex bg-slate-50">
+      <aside className="w-56 bg-slate-900 text-white flex flex-col p-4">
+        <div className="font-bold mb-6">HRMS</div>
+        <nav className="flex-1 space-y-2">
+          {links.map(l => (
+            <Link key={l.to} to={l.to} className="block hover:underline">
+              {l.label}
+            </Link>
+          ))}
+        </nav>
+        <div className="pt-4 border-t border-slate-700 text-sm">
+          <div className="mb-2">{u?.subRoles.join(', ')}</div>
+          <button
+            onClick={() => {
+              clearAuth();
+              nav('/login');
+            }}
+            className="underline"
+          >
+            Logout
+          </button>
         </div>
-      </header>
-      <nav className="px-6 py-3 bg-slate-100 border-b">
-        <Link className="mr-4" to="/app">Dashboard</Link>
-      </nav>
-      <main className="p-6">
+      </aside>
+      <main className="flex-1 p-6">
         <Outlet />
       </main>
     </div>

--- a/apps/web/src/pages/admin/AddUser.tsx
+++ b/apps/web/src/pages/admin/AddUser.tsx
@@ -1,0 +1,61 @@
+import { useState, FormEvent } from 'react';
+import { api } from '../../lib/api';
+
+export default function AddUser() {
+  const [form, setForm] = useState({
+    name: '',
+    email: '',
+    password: '',
+    role: 'hr'
+  });
+
+  async function submit(e: FormEvent) {
+    e.preventDefault();
+    try {
+      await api.post('/companies/users', form);
+      setForm({ name: '', email: '', password: '', role: 'hr' });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-2xl font-semibold">Add User</h2>
+      <form onSubmit={submit} className="space-y-2 max-w-md">
+        <input
+          className="w-full border p-1"
+          placeholder="Name"
+          value={form.name}
+          onChange={e => setForm({ ...form, name: e.target.value })}
+        />
+        <input
+          className="w-full border p-1"
+          placeholder="Email"
+          type="email"
+          value={form.email}
+          onChange={e => setForm({ ...form, email: e.target.value })}
+        />
+        <input
+          className="w-full border p-1"
+          placeholder="Password"
+          type="password"
+          value={form.password}
+          onChange={e => setForm({ ...form, password: e.target.value })}
+        />
+        <select
+          className="w-full border p-1"
+          value={form.role}
+          onChange={e => setForm({ ...form, role: e.target.value })}
+        >
+          <option value="hr">HR</option>
+          <option value="manager">Manager</option>
+          <option value="developer">Developer</option>
+        </select>
+        <button className="px-4 py-1 bg-blue-500 text-white" type="submit">
+          Add User
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/src/pages/admin/AttendanceList.tsx
+++ b/apps/web/src/pages/admin/AttendanceList.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import { api } from '../../lib/api';
+
+interface AttendanceRecord {
+  user: { id: string; name: string };
+  firstPunchIn?: string;
+  lastPunchOut?: string;
+}
+
+export default function AttendanceList() {
+  const [attendance, setAttendance] = useState<AttendanceRecord[]>([]);
+
+  useEffect(() => {
+    api
+      .get('/attendance/company/today')
+      .then(res => setAttendance(res.data.attendance))
+      .catch(err => console.error(err));
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-2xl font-semibold">Attendance</h2>
+      <table className="w-full text-sm border">
+        <thead>
+          <tr className="border-b">
+            <th className="p-1 text-left">Name</th>
+            <th className="p-1 text-left">First In</th>
+            <th className="p-1 text-left">Last Out</th>
+          </tr>
+        </thead>
+        <tbody>
+          {attendance.map(a => (
+            <tr key={a.user.id} className="border-b">
+              <td className="p-1">{a.user.name}</td>
+              <td className="p-1">
+                {a.firstPunchIn ? new Date(a.firstPunchIn).toLocaleTimeString() : '-'}
+              </td>
+              <td className="p-1">
+                {a.lastPunchOut ? new Date(a.lastPunchOut).toLocaleTimeString() : '-'}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/src/pages/admin/Dashboard.tsx
+++ b/apps/web/src/pages/admin/Dashboard.tsx
@@ -1,144 +1,32 @@
-import { useEffect, useState, FormEvent } from 'react';
+import { useEffect, useState } from 'react';
 import { api } from '../../lib/api';
 
-interface CompanyUser {
-  id: string;
-  name: string;
-  email: string;
-  subRoles: string[];
-}
-
-interface AttendanceRecord {
-  user: { id: string; name: string };
-  firstPunchIn?: string;
-  lastPunchOut?: string;
-}
-
 export default function AdminDash() {
-  const [users, setUsers] = useState<CompanyUser[]>([]);
-  const [form, setForm] = useState({ name: '', email: '', password: '', role: 'hr' });
-  const [attendance, setAttendance] = useState<AttendanceRecord[]>([]);
-
-  async function load() {
-    try {
-      const res = await api.get('/companies/users');
-      setUsers(res.data.users);
-      const att = await api.get('/attendance/company/today');
-      setAttendance(att.data.attendance);
-    } catch (e) {
-      console.error(e);
-    }
-  }
+  const [stats, setStats] = useState({ users: 0, present: 0 });
 
   useEffect(() => {
+    async function load() {
+      try {
+        const users = await api.get('/companies/users');
+        const att = await api.get('/attendance/company/today');
+        setStats({
+          users: users.data.users.length,
+          present: att.data.attendance.length
+        });
+      } catch (err) {
+        console.error(err);
+      }
+    }
     load();
   }, []);
 
-  async function submit(e: FormEvent) {
-    e.preventDefault();
-    try {
-      await api.post('/companies/users', form);
-      setForm({ name: '', email: '', password: '', role: 'hr' });
-      load();
-    } catch (err) {
-      console.error(err);
-    }
-  }
-
   return (
     <div className="space-y-6">
-      <div className="space-y-2">
-        <h2 className="text-2xl font-semibold">Admin Dashboard</h2>
-        <div className="text-sm">Company settings, departments, roles</div>
-      </div>
-
-      <form onSubmit={submit} className="space-y-2 max-w-md">
-        <input
-          className="w-full border p-1"
-          placeholder="Name"
-          value={form.name}
-          onChange={e => setForm({ ...form, name: e.target.value })}
-        />
-        <input
-          className="w-full border p-1"
-          placeholder="Email"
-          type="email"
-          value={form.email}
-          onChange={e => setForm({ ...form, email: e.target.value })}
-        />
-        <input
-          className="w-full border p-1"
-          placeholder="Password"
-          type="password"
-          value={form.password}
-          onChange={e => setForm({ ...form, password: e.target.value })}
-        />
-        <select
-          className="w-full border p-1"
-          value={form.role}
-          onChange={e => setForm({ ...form, role: e.target.value })}
-        >
-          <option value="hr">HR</option>
-          <option value="manager">Manager</option>
-          <option value="developer">Developer</option>
-        </select>
-        <button className="px-4 py-1 bg-blue-500 text-white" type="submit">
-          Add User
-        </button>
-      </form>
-
-      <div>
-        <h3 className="font-semibold mb-2">Company Users</h3>
-        <table className="w-full text-sm border">
-          <thead>
-            <tr className="border-b">
-              <th className="p-1 text-left">Name</th>
-              <th className="p-1 text-left">Email</th>
-              <th className="p-1 text-left">Role</th>
-            </tr>
-          </thead>
-          <tbody>
-            {users.map(u => (
-              <tr key={u.id} className="border-b">
-                <td className="p-1">{u.name}</td>
-                <td className="p-1">{u.email}</td>
-                <td className="p-1">{u.subRoles[0]}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-
-      <div>
-        <h3 className="font-semibold mb-2">Today's Attendance</h3>
-        <table className="w-full text-sm border">
-          <thead>
-            <tr className="border-b">
-              <th className="p-1 text-left">Name</th>
-              <th className="p-1 text-left">First In</th>
-              <th className="p-1 text-left">Last Out</th>
-            </tr>
-          </thead>
-          <tbody>
-            {attendance.map(a => (
-              <tr key={a.user.id} className="border-b">
-                <td className="p-1">{a.user.name}</td>
-                <td className="p-1">
-                  {a.firstPunchIn
-                    ? new Date(a.firstPunchIn).toLocaleTimeString()
-                    : '-'}
-                </td>
-                <td className="p-1">
-                  {a.lastPunchOut
-                    ? new Date(a.lastPunchOut).toLocaleTimeString()
-                    : '-'}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+      <h2 className="text-2xl font-semibold">Admin Dashboard</h2>
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="p-4 bg-blue-100 rounded">Total Users: {stats.users}</div>
+        <div className="p-4 bg-green-100 rounded">Today's Attendance: {stats.present}</div>
       </div>
     </div>
   );
 }
-

--- a/apps/web/src/pages/admin/UserList.tsx
+++ b/apps/web/src/pages/admin/UserList.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { api } from '../../lib/api';
+
+interface CompanyUser {
+  id: string;
+  name: string;
+  email: string;
+  subRoles: string[];
+}
+
+export default function UserList() {
+  const [users, setUsers] = useState<CompanyUser[]>([]);
+
+  useEffect(() => {
+    api
+      .get('/companies/users')
+      .then(res => setUsers(res.data.users))
+      .catch(err => console.error(err));
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-2xl font-semibold">User List</h2>
+      <table className="w-full text-sm border">
+        <thead>
+          <tr className="border-b">
+            <th className="p-1 text-left">Name</th>
+            <th className="p-1 text-left">Email</th>
+            <th className="p-1 text-left">Role</th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.map(u => (
+            <tr key={u.id} className="border-b">
+              <td className="p-1">{u.name}</td>
+              <td className="p-1">{u.email}</td>
+              <td className="p-1">{u.subRoles[0]}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/src/pages/superadmin/AddCompany.tsx
+++ b/apps/web/src/pages/superadmin/AddCompany.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useState, FormEvent } from 'react';
+import { api } from '../../lib/api';
+
+type Company = {
+  _id: string;
+  name: string;
+  admin?: { name: string; email: string };
+};
+
+export default function AddCompany() {
+  const [companies, setCompanies] = useState<Company[]>([]);
+  const [companyName, setCompanyName] = useState('');
+  const [adminName, setAdminName] = useState('');
+  const [adminEmail, setAdminEmail] = useState('');
+  const [adminPassword, setAdminPassword] = useState('');
+  const [existingCompany, setExistingCompany] = useState('');
+  const [newAdminName, setNewAdminName] = useState('');
+  const [newAdminEmail, setNewAdminEmail] = useState('');
+  const [newAdminPassword, setNewAdminPassword] = useState('');
+
+  function load() {
+    api
+      .get('/companies')
+      .then(res => setCompanies(res.data.companies))
+      .catch(err => console.error(err));
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function submit(e: FormEvent) {
+    e.preventDefault();
+    try {
+      await api.post('/companies', {
+        companyName,
+        adminName,
+        adminEmail,
+        adminPassword
+      });
+      setCompanyName('');
+      setAdminName('');
+      setAdminEmail('');
+      setAdminPassword('');
+      load();
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async function submitExisting(e: FormEvent) {
+    e.preventDefault();
+    try {
+      await api.post(`/companies/${existingCompany}/admin`, {
+        adminName: newAdminName,
+        adminEmail: newAdminEmail,
+        adminPassword: newAdminPassword
+      });
+      setExistingCompany('');
+      setNewAdminName('');
+      setNewAdminEmail('');
+      setNewAdminPassword('');
+      load();
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <h2 className="text-2xl font-semibold">Add Company</h2>
+
+      <form onSubmit={submit} className="space-y-2 max-w-md">
+        <input
+          className="w-full border p-1"
+          placeholder="Company Name"
+          value={companyName}
+          onChange={e => setCompanyName(e.target.value)}
+        />
+        <input
+          className="w-full border p-1"
+          placeholder="Admin Name"
+          value={adminName}
+          onChange={e => setAdminName(e.target.value)}
+        />
+        <input
+          className="w-full border p-1"
+          placeholder="Admin Email"
+          type="email"
+          value={adminEmail}
+          onChange={e => setAdminEmail(e.target.value)}
+        />
+        <input
+          className="w-full border p-1"
+          placeholder="Admin Password"
+          type="password"
+          value={adminPassword}
+          onChange={e => setAdminPassword(e.target.value)}
+        />
+        <button className="px-4 py-1 bg-blue-500 text-white" type="submit">
+          Add Company
+        </button>
+      </form>
+
+      <form onSubmit={submitExisting} className="space-y-2 max-w-md">
+        <h3 className="font-semibold">Add Admin to Company</h3>
+        <select
+          className="w-full border p-1"
+          value={existingCompany}
+          onChange={e => setExistingCompany(e.target.value)}
+        >
+          <option value="">Select Company</option>
+          {companies.filter(c => !c.admin).map(c => (
+            <option key={c._id} value={c._id}>
+              {c.name}
+            </option>
+          ))}
+        </select>
+        <input
+          className="w-full border p-1"
+          placeholder="Admin Name"
+          value={newAdminName}
+          onChange={e => setNewAdminName(e.target.value)}
+        />
+        <input
+          className="w-full border p-1"
+          placeholder="Admin Email"
+          type="email"
+          value={newAdminEmail}
+          onChange={e => setNewAdminEmail(e.target.value)}
+        />
+        <input
+          className="w-full border p-1"
+          placeholder="Admin Password"
+          type="password"
+          value={newAdminPassword}
+          onChange={e => setNewAdminPassword(e.target.value)}
+        />
+        <button
+          className="px-4 py-1 bg-blue-500 text-white"
+          type="submit"
+          disabled={!existingCompany}
+        >
+          Add Admin
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/src/pages/superadmin/CompanyList.tsx
+++ b/apps/web/src/pages/superadmin/CompanyList.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import { api } from '../../lib/api';
+
+type Company = {
+  _id: string;
+  name: string;
+  admin?: { name: string; email: string };
+};
+
+export default function CompanyList() {
+  const [companies, setCompanies] = useState<Company[]>([]);
+
+  useEffect(() => {
+    api
+      .get('/companies')
+      .then(res => setCompanies(res.data.companies))
+      .catch(err => console.error(err));
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-2xl font-semibold">Company List</h2>
+      <ul className="space-y-1 text-sm">
+        {companies.map(c => (
+          <li key={c._id}>
+            {c.name} – {c.admin ? `${c.admin.name} (${c.admin.email})` : 'No admin'}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/pages/superadmin/Dashboard.tsx
+++ b/apps/web/src/pages/superadmin/Dashboard.tsx
@@ -1,155 +1,21 @@
-import { useEffect, useState, FormEvent } from 'react';
+import { useEffect, useState } from 'react';
 import { api } from '../../lib/api';
 
-type Company = {
-  _id: string;
-  name: string;
-  admin?: { name: string; email: string };
-};
-
 export default function SADash() {
-  const [companies, setCompanies] = useState<Company[]>([]);
-  const [companyName, setCompanyName] = useState('');
-  const [adminName, setAdminName] = useState('');
-  const [adminEmail, setAdminEmail] = useState('');
-  const [adminPassword, setAdminPassword] = useState('');
-  const [existingCompany, setExistingCompany] = useState('');
-  const [newAdminName, setNewAdminName] = useState('');
-  const [newAdminEmail, setNewAdminEmail] = useState('');
-  const [newAdminPassword, setNewAdminPassword] = useState('');
-
-  async function load() {
-    try {
-      const res = await api.get('/companies');
-      setCompanies(res.data.companies);
-    } catch (e) {
-      console.error(e);
-    }
-  }
+  const [count, setCount] = useState(0);
 
   useEffect(() => {
-    load();
+    api
+      .get('/companies')
+      .then(res => setCount(res.data.companies.length))
+      .catch(err => console.error(err));
   }, []);
-
-  async function submit(e: FormEvent) {
-    e.preventDefault();
-    try {
-      await api.post('/companies', { companyName, adminName, adminEmail, adminPassword });
-      setCompanyName('');
-      setAdminName('');
-      setAdminEmail('');
-      setAdminPassword('');
-      load();
-    } catch (err) {
-      console.error(err);
-    }
-  }
-
-  async function submitExisting(e: FormEvent) {
-    e.preventDefault();
-    try {
-      await api.post(`/companies/${existingCompany}/admin`, {
-        adminName: newAdminName,
-        adminEmail: newAdminEmail,
-        adminPassword: newAdminPassword
-      });
-      setExistingCompany('');
-      setNewAdminName('');
-      setNewAdminEmail('');
-      setNewAdminPassword('');
-      load();
-    } catch (err) {
-      console.error(err);
-    }
-  }
 
   return (
     <div className="space-y-6">
-      <div className="space-y-2">
-        <h2 className="text-2xl font-semibold">Superadmin Dashboard</h2>
-        <div className="text-sm">Manage tenants, admins, and global settings</div>
-      </div>
-
-      <form onSubmit={submit} className="space-y-2 max-w-md">
-        <input
-          className="w-full border p-1"
-          placeholder="Company Name"
-          value={companyName}
-          onChange={e => setCompanyName(e.target.value)}
-        />
-        <input
-          className="w-full border p-1"
-          placeholder="Admin Name"
-          value={adminName}
-          onChange={e => setAdminName(e.target.value)}
-        />
-        <input
-          className="w-full border p-1"
-          placeholder="Admin Email"
-          type="email"
-          value={adminEmail}
-          onChange={e => setAdminEmail(e.target.value)}
-        />
-        <input
-          className="w-full border p-1"
-          placeholder="Admin Password"
-          type="password"
-          value={adminPassword}
-          onChange={e => setAdminPassword(e.target.value)}
-        />
-        <button className="px-4 py-1 bg-blue-500 text-white" type="submit">
-          Add Company
-        </button>
-      </form>
-
-      <form onSubmit={submitExisting} className="space-y-2 max-w-md">
-        <h3 className="font-semibold">Add Admin to Company</h3>
-        <select
-          className="w-full border p-1"
-          value={existingCompany}
-          onChange={e => setExistingCompany(e.target.value)}
-        >
-          <option value="">Select Company</option>
-          {companies.filter(c => !c.admin).map(c => (
-            <option key={c._id} value={c._id}>
-              {c.name}
-            </option>
-          ))}
-        </select>
-        <input
-          className="w-full border p-1"
-          placeholder="Admin Name"
-          value={newAdminName}
-          onChange={e => setNewAdminName(e.target.value)}
-        />
-        <input
-          className="w-full border p-1"
-          placeholder="Admin Email"
-          type="email"
-          value={newAdminEmail}
-          onChange={e => setNewAdminEmail(e.target.value)}
-        />
-        <input
-          className="w-full border p-1"
-          placeholder="Admin Password"
-          type="password"
-          value={newAdminPassword}
-          onChange={e => setNewAdminPassword(e.target.value)}
-        />
-        <button className="px-4 py-1 bg-blue-500 text-white" type="submit" disabled={!existingCompany}>
-          Add Admin
-        </button>
-      </form>
-
-      <div>
-        <h3 className="font-semibold mb-2">Companies</h3>
-        <ul className="space-y-1">
-          {companies.map(c => (
-            <li key={c._id} className="text-sm">
-              {c.name} – {c.admin ? `${c.admin.name} (${c.admin.email})` : 'No admin'}
-            </li>
-          ))}
-        </ul>
+      <h2 className="text-2xl font-semibold">Superadmin Dashboard</h2>
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="p-4 bg-gray-100 rounded">Total Companies: {count}</div>
       </div>
     </div>
   );

--- a/apps/web/src/pages/user/AttendanceRecords.tsx
+++ b/apps/web/src/pages/user/AttendanceRecords.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import { api } from '../../lib/api';
+
+interface Record {
+  date: string;
+  firstPunchIn?: string;
+  lastPunchOut?: string;
+}
+
+export default function AttendanceRecords() {
+  const [records, setRecords] = useState<Record[]>([]);
+
+  useEffect(() => {
+    api
+      .get('/attendance/history')
+      .then(res => setRecords(res.data.attendance))
+      .catch(err => console.error(err));
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-2xl font-semibold">Attendance Records</h2>
+      <table className="w-full text-sm border">
+        <thead>
+          <tr className="border-b">
+            <th className="p-1 text-left">Date</th>
+            <th className="p-1 text-left">First In</th>
+            <th className="p-1 text-left">Last Out</th>
+          </tr>
+        </thead>
+        <tbody>
+          {records.map(r => (
+            <tr key={r.date} className="border-b">
+              <td className="p-1">{new Date(r.date).toLocaleDateString()}</td>
+              <td className="p-1">
+                {r.firstPunchIn ? new Date(r.firstPunchIn).toLocaleTimeString() : '-'}
+              </td>
+              <td className="p-1">
+                {r.lastPunchOut ? new Date(r.lastPunchOut).toLocaleTimeString() : '-'}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add sidebar navigation for super admins, admins and users
- split dashboards into dedicated pages for companies, users and attendance
- provide attendance history page for users

## Testing
- `npm run build -w apps/web`


------
https://chatgpt.com/codex/tasks/task_e_68ac38bf8eb8832b8fcf718159bff26e