### PR TITLE
feat: add leave approval workflow

### DIFF
--- a/apps/api/src/index.js
+++ b/apps/api/src/index.js
@@ -13,6 +13,7 @@ app.use('/auth', require('./routes/auth'));
 app.use('/seed', require('./routes/seed'));
 app.use('/companies', require('./routes/companies'));
 app.use('/attendance', require('./routes/attendance'));
+app.use('/leaves', require('./routes/leaves'));
 
 connectDB().then(() => {
   const port = process.env.PORT || 4000;

--- a/apps/api/src/models/Leave.js
+++ b/apps/api/src/models/Leave.js
@@ -1,0 +1,16 @@
+const mongoose = require('mongoose');
+
+const LeaveSchema = new mongoose.Schema(
+  {
+    user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    company: { type: mongoose.Schema.Types.ObjectId, ref: 'Company', required: true },
+    startDate: { type: Date, required: true },
+    endDate: { type: Date, required: true },
+    reason: { type: String },
+    status: { type: String, enum: ['PENDING', 'APPROVED', 'REJECTED'], default: 'PENDING' },
+    adminMessage: { type: String }
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('Leave', LeaveSchema);

--- a/apps/api/src/routes/leaves.js
+++ b/apps/api/src/routes/leaves.js
@@ -1,0 +1,62 @@
+const router = require('express').Router();
+const Leave = require('../models/Leave');
+const { auth } = require('../middleware/auth');
+const { requirePrimary } = require('../middleware/roles');
+
+// User creates a leave request
+router.post('/', auth, async (req, res) => {
+  const { startDate, endDate, reason } = req.body;
+  try {
+    const leave = await Leave.create({
+      user: req.user.id,
+      company: req.user.company,
+      startDate,
+      endDate,
+      reason
+    });
+    res.json({ leave });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// User views their leave requests
+router.get('/', auth, async (req, res) => {
+  const leaves = await Leave.find({ user: req.user.id })
+    .sort({ createdAt: -1 })
+    .lean();
+  res.json({ leaves });
+});
+
+// Admin views company leave requests
+router.get('/company', auth, requirePrimary(['ADMIN', 'SUPERADMIN']), async (req, res) => {
+  const leaves = await Leave.find({ company: req.user.company })
+    .populate('user', 'name')
+    .sort({ createdAt: -1 })
+    .lean();
+  res.json({ leaves });
+});
+
+// Admin approves a leave
+router.post('/:id/approve', auth, requirePrimary(['ADMIN', 'SUPERADMIN']), async (req, res) => {
+  const leave = await Leave.findByIdAndUpdate(
+    req.params.id,
+    { status: 'APPROVED', adminMessage: req.body.message },
+    { new: true }
+  );
+  if (!leave) return res.status(404).json({ error: 'Not found' });
+  res.json({ leave });
+});
+
+// Admin rejects a leave
+router.post('/:id/reject', auth, requirePrimary(['ADMIN', 'SUPERADMIN']), async (req, res) => {
+  const leave = await Leave.findByIdAndUpdate(
+    req.params.id,
+    { status: 'REJECTED', adminMessage: req.body.message },
+    { new: true }
+  );
+  if (!leave) return res.status(404).json({ error: 'Not found' });
+  res.json({ leave });
+});
+
+module.exports = router;

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -13,9 +13,11 @@ import AdminDash from './pages/admin/Dashboard';
 import AddUser from './pages/admin/AddUser';
 import UserList from './pages/admin/UserList';
 import AttendanceList from './pages/admin/AttendanceList';
+import LeaveRequests from './pages/admin/LeaveRequests';
 
 import UserDash from './pages/user/Dashboard';
 import AttendanceRecords from './pages/user/AttendanceRecords';
+import LeaveRequest from './pages/user/LeaveRequest';
 
 export default function App() {
   return (
@@ -51,6 +53,7 @@ export default function App() {
         <Route path="users/add" element={<AddUser />} />
         <Route path="users" element={<UserList />} />
         <Route path="attendances" element={<AttendanceList />} />
+        <Route path="leaves" element={<LeaveRequests />} />
       </Route>
 
       <Route
@@ -65,6 +68,7 @@ export default function App() {
       >
         <Route index element={<UserDash />} />
         <Route path="attendance" element={<AttendanceRecords />} />
+        <Route path="leave" element={<LeaveRequest />} />
       </Route>
 
       <Route path="*" element={<Navigate to="/login" replace />} />

--- a/apps/web/src/layouts/AdminLayout.tsx
+++ b/apps/web/src/layouts/AdminLayout.tsx
@@ -9,7 +9,8 @@ export default function AdminLayout() {
     { to: '/admin', label: 'Dashboard' },
     { to: '/admin/users/add', label: 'Add User' },
     { to: '/admin/users', label: 'User List' },
-    { to: '/admin/attendances', label: 'Attendances' }
+    { to: '/admin/attendances', label: 'Attendances' },
+    { to: '/admin/leaves', label: 'Leave Requests' }
   ];
 
   return (

--- a/apps/web/src/layouts/UserLayout.tsx
+++ b/apps/web/src/layouts/UserLayout.tsx
@@ -7,7 +7,8 @@ export default function UserLayout() {
 
   const links = [
     { to: '/app', label: 'Dashboard' },
-    { to: '/app/attendance', label: 'Attendance' }
+    { to: '/app/attendance', label: 'Attendance' },
+    { to: '/app/leave', label: 'Leave' }
   ];
 
   return (

--- a/apps/web/src/pages/admin/LeaveRequests.tsx
+++ b/apps/web/src/pages/admin/LeaveRequests.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react';
+import { api } from '../../lib/api';
+
+interface Leave {
+  _id: string;
+  user: { _id: string; name: string };
+  startDate: string;
+  endDate: string;
+  reason?: string;
+  status: string;
+  adminMessage?: string;
+}
+
+export default function LeaveRequests() {
+  const [leaves, setLeaves] = useState<Leave[]>([]);
+
+  function load() {
+    api
+      .get('/leaves/company')
+      .then(res => setLeaves(res.data.leaves))
+      .catch(err => console.error(err));
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function decide(id: string, action: 'approve' | 'reject') {
+    const message = prompt('Message');
+    try {
+      await api.post(`/leaves/${id}/${action}`, { message });
+      load();
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-2xl font-semibold">Leave Requests</h2>
+      <table className="w-full text-sm border">
+        <thead>
+          <tr className="border-b">
+            <th className="p-1 text-left">User</th>
+            <th className="p-1 text-left">Start</th>
+            <th className="p-1 text-left">End</th>
+            <th className="p-1 text-left">Status</th>
+            <th className="p-1 text-left">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {leaves.map(l => (
+            <tr key={l._id} className="border-b">
+              <td className="p-1">{l.user.name}</td>
+              <td className="p-1">{new Date(l.startDate).toLocaleDateString()}</td>
+              <td className="p-1">{new Date(l.endDate).toLocaleDateString()}</td>
+              <td className="p-1">{l.status}</td>
+              <td className="p-1 space-x-2">
+                {l.status === 'PENDING' && (
+                  <>
+                    <button
+                      className="px-2 py-0.5 bg-green-500 text-white"
+                      onClick={() => decide(l._id, 'approve')}
+                    >
+                      Approve
+                    </button>
+                    <button
+                      className="px-2 py-0.5 bg-red-500 text-white"
+                      onClick={() => decide(l._id, 'reject')}
+                    >
+                      Reject
+                    </button>
+                  </>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/src/pages/user/LeaveRequest.tsx
+++ b/apps/web/src/pages/user/LeaveRequest.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useState, FormEvent } from 'react';
+import { api } from '../../lib/api';
+
+interface Leave {
+  _id: string;
+  startDate: string;
+  endDate: string;
+  reason?: string;
+  status: string;
+  adminMessage?: string;
+}
+
+export default function LeaveRequest() {
+  const [form, setForm] = useState({ startDate: '', endDate: '', reason: '' });
+  const [leaves, setLeaves] = useState<Leave[]>([]);
+
+  function load() {
+    api
+      .get('/leaves')
+      .then(res => setLeaves(res.data.leaves))
+      .catch(err => console.error(err));
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function submit(e: FormEvent) {
+    e.preventDefault();
+    try {
+      await api.post('/leaves', form);
+      setForm({ startDate: '', endDate: '', reason: '' });
+      load();
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <h2 className="text-2xl font-semibold">Request Leave</h2>
+      <form onSubmit={submit} className="space-y-2 max-w-md">
+        <input
+          type="date"
+          className="w-full border p-1"
+          value={form.startDate}
+          onChange={e => setForm({ ...form, startDate: e.target.value })}
+        />
+        <input
+          type="date"
+          className="w-full border p-1"
+          value={form.endDate}
+          onChange={e => setForm({ ...form, endDate: e.target.value })}
+        />
+        <textarea
+          className="w-full border p-1"
+          placeholder="Reason"
+          value={form.reason}
+          onChange={e => setForm({ ...form, reason: e.target.value })}
+        />
+        <button type="submit" className="px-4 py-1 bg-blue-500 text-white">
+          Submit
+        </button>
+      </form>
+
+      <table className="w-full text-sm border">
+        <thead>
+          <tr className="border-b">
+            <th className="p-1 text-left">Start</th>
+            <th className="p-1 text-left">End</th>
+            <th className="p-1 text-left">Status</th>
+            <th className="p-1 text-left">Message</th>
+          </tr>
+        </thead>
+        <tbody>
+          {leaves.map(l => (
+            <tr key={l._id} className="border-b">
+              <td className="p-1">{new Date(l.startDate).toLocaleDateString()}</td>
+              <td className="p-1">{new Date(l.endDate).toLocaleDateString()}</td>
+              <td className="p-1">{l.status}</td>
+              <td className="p-1">{l.adminMessage || '-'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Leave schema and API routes for requesting and approving leave
- expose new leave endpoints in API
- build UI pages for users to request leave and admins to approve/reject

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: Missing script: "build")

------
https://chatgpt.com/codex/tasks/task_e_68ac3a7443f0832bb7ee757e932dfbb5