### PR TITLE
Add attendance history API endpoints and admin monthly view

### DIFF
--- a/apps/web/src/pages/admin/AttendanceList.tsx
+++ b/apps/web/src/pages/admin/AttendanceList.tsx
@@ -7,10 +7,17 @@ type AttendanceRecord = {
   lastPunchOut?: string;
 };
 
+type MonthRecord = AttendanceRecord & { date: string };
+
 function formatTime(ts?: string) {
   if (!ts) return "-";
   const d = new Date(ts);
   return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+function formatDate(ts: string) {
+  const d = new Date(ts);
+  return d.toLocaleDateString();
 }
 
 function formatElapsed(ms: number) {
@@ -26,10 +33,14 @@ function formatElapsed(ms: number) {
 
 export default function AttendanceList() {
   const [rows, setRows] = useState<AttendanceRecord[]>([]);
+  const [monthRows, setMonthRows] = useState<MonthRecord[]>([]);
   const [loading, setLoading] = useState(true);
+  const [monthLoading, setMonthLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [q, setQ] = useState("");
   const [now, setNow] = useState(Date.now());
+  const [view, setView] = useState<"today" | "month">("today");
+  const [month, setMonth] = useState(new Date().toISOString().slice(0, 7));
 
   async function load() {
     try {
@@ -44,20 +55,39 @@ export default function AttendanceList() {
     }
   }
 
-  // initial + pull every 60s
+  async function loadMonth() {
+    try {
+      setMonthLoading(true);
+      setErr(null);
+      const res = await api.get("/attendance/company/history", { params: { month } });
+      setMonthRows(res.data.attendance || []);
+    } catch (e: any) {
+      setErr(e?.response?.data?.error || "Failed to load attendance");
+    } finally {
+      setMonthLoading(false);
+    }
+  }
+
+  // initial + pull every 60s for today view
   useEffect(() => {
+    if (view !== "today") return;
     load();
     const id = setInterval(load, 60000);
     return () => clearInterval(id);
-  }, []);
+  }, [view]);
 
   // tick per minute for live elapsed of "IN" users
   useEffect(() => {
+    if (view !== "today") return;
     const id = setInterval(() => setNow(Date.now()), 60000);
     return () => clearInterval(id);
-  }, []);
+  }, [view]);
 
-  const filtered = useMemo(() => {
+  useEffect(() => {
+    if (view === "month") loadMonth();
+  }, [view, month]);
+
+  const filteredToday = useMemo(() => {
     const term = q.trim().toLowerCase();
     const base = term
       ? rows.filter((r) => r.employee.name.toLowerCase().includes(term))
@@ -72,28 +102,74 @@ export default function AttendanceList() {
     });
   }, [rows, q]);
 
+  const filteredMonth = useMemo(() => {
+    const term = q.trim().toLowerCase();
+    const base = term
+      ? monthRows.filter((r) => r.employee.name.toLowerCase().includes(term))
+      : monthRows;
+    return [...base].sort(
+      (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+    );
+  }, [monthRows, q]);
+
+
   return (
     <div className="space-y-8">
       <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
         <div>
-          <h2 className="text-3xl font-bold">Attendance (Today)</h2>
+          <h2 className="text-3xl font-bold">
+            {view === "today" ? "Attendance (Today)" : "Attendance (Month)"}
+          </h2>
           <p className="text-sm text-muted">
-            Live status of employees who have punched in/out today.
+            {view === "today"
+              ? "Live status of employees who have punched in/out today."
+              : "Attendance records for the selected month."}
           </p>
         </div>
-        <div className="flex gap-2">
+        <div className="flex gap-2 flex-wrap items-center">
           <input
             value={q}
             onChange={(e) => setQ(e.target.value)}
             placeholder="Search employee…"
             className="h-10 w-72 rounded-md border border-border bg-surface px-3 outline-none focus:ring-2 focus:ring-primary"
           />
-          <button
-            onClick={load}
-            className="h-10 rounded-md bg-primary px-4 text-white"
-          >
-            Refresh
-          </button>
+          {view === "today" ? (
+            <>
+              <button
+                onClick={load}
+                className="h-10 rounded-md bg-primary px-4 text-white"
+              >
+                Refresh
+              </button>
+              <button
+                onClick={() => setView("month")}
+                className="h-10 rounded-md border border-border px-3"
+              >
+                Month View
+              </button>
+            </>
+          ) : (
+            <>
+              <input
+                type="month"
+                value={month}
+                onChange={(e) => setMonth(e.target.value)}
+                className="h-10 rounded-md border border-border bg-surface px-3"
+              />
+              <button
+                onClick={loadMonth}
+                className="h-10 rounded-md bg-primary px-4 text-white"
+              >
+                Load
+              </button>
+              <button
+                onClick={() => setView("today")}
+                className="h-10 rounded-md border border-border px-3"
+              >
+                Today
+              </button>
+            </>
+          )}
         </div>
       </div>
 
@@ -103,122 +179,205 @@ export default function AttendanceList() {
         </div>
       )}
 
-      <section className="rounded-lg border border-border bg-surface shadow-sm overflow-hidden">
-        <div className="border-b border-border px-4 py-3 flex items-center justify-between">
-          <div className="text-sm text-muted">
-            {loading
-              ? "Loading…"
-              : `${filtered.length} ${
-                  filtered.length === 1 ? "employee" : "employees"
-                }`}
+      {view === "today" ? (
+        <section className="rounded-lg border border-border bg-surface shadow-sm overflow-hidden">
+          <div className="border-b border-border px-4 py-3 flex items-center justify-between">
+            <div className="text-sm text-muted">
+              {loading
+                ? "Loading…"
+                : `${filteredToday.length} ${
+                    filteredToday.length === 1 ? "employee" : "employees"
+                  }`}
+            </div>
+            <div className="text-xs text-muted">
+              Updated{" "}
+              {new Date(now).toLocaleTimeString([], {
+                hour: "2-digit",
+                minute: "2-digit",
+              })}
+            </div>
           </div>
-          <div className="text-xs text-muted">
-            Updated{" "}
-            {new Date(now).toLocaleTimeString([], {
-              hour: "2-digit",
-              minute: "2-digit",
-            })}
-          </div>
-        </div>
 
-        {/* Desktop table */}
-        <div className="hidden md:block">
-          <table className="w-full text-sm">
-            <thead className="bg-bg">
-              <tr className="text-left">
-                <Th>Name</Th>
-                <Th>First In</Th>
-                <Th>Last Out</Th>
-                <Th>Status</Th>
-                <Th>Elapsed</Th>
-              </tr>
-            </thead>
-            <tbody>
-              {loading ? (
-                <SkeletonRows rows={6} cols={5} />
-              ) : filtered.length === 0 ? (
-                <tr>
-                  <td colSpan={5} className="px-4 py-6 text-center text-muted">
-                    No attendance records yet.
-                  </td>
+          {/* Desktop table */}
+          <div className="hidden md:block">
+            <table className="w-full text-sm">
+              <thead className="bg-bg">
+                <tr className="text-left">
+                  <Th>Name</Th>
+                  <Th>First In</Th>
+                  <Th>Last Out</Th>
+                  <Th>Status</Th>
+                  <Th>Elapsed</Th>
                 </tr>
-              ) : (
-                filtered.map((a) => {
-                  const isIn = !!a.firstPunchIn && !a.lastPunchOut;
-                  const elapsed = a.firstPunchIn
-                    ? isIn
-                      ? now - new Date(a.firstPunchIn).getTime()
-                      : new Date(a.lastPunchOut || 0).getTime() -
-                        new Date(a.firstPunchIn).getTime()
-                    : 0;
-                  return (
+              </thead>
+              <tbody>
+                {loading ? (
+                  <SkeletonRows rows={6} cols={5} />
+                ) : filteredToday.length === 0 ? (
+                  <tr>
+                    <td colSpan={5} className="px-4 py-6 text-center text-muted">
+                      No attendance records yet.
+                    </td>
+                  </tr>
+                ) : (
+                  filteredToday.map((a) => {
+                    const isIn = !!a.firstPunchIn && !a.lastPunchOut;
+                    const elapsed = a.firstPunchIn
+                      ? isIn
+                        ? now - new Date(a.firstPunchIn).getTime()
+                        : new Date(a.lastPunchOut || 0).getTime() -
+                          new Date(a.firstPunchIn).getTime()
+                      : 0;
+                    return (
+                      <tr
+                        key={a.employee.id}
+                        className="border-t border-border/70"
+                      >
+                        <Td className="font-medium">{a.employee.name}</Td>
+                        <Td>{formatTime(a.firstPunchIn)}</Td>
+                        <Td>{formatTime(a.lastPunchOut)}</Td>
+                        <Td>
+                          <StatusBadge inOffice={isIn} />
+                        </Td>
+                        <Td>{a.firstPunchIn ? formatElapsed(elapsed) : "-"}</Td>
+                      </tr>
+                    );
+                  })
+                )}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Mobile cards */}
+          <div className="md:hidden divide-y divide-border">
+            {loading ? (
+              <div className="p-4 space-y-3">
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <div
+                    key={i}
+                    className="rounded-md border border-border p-3 animate-pulse space-y-2"
+                  >
+                    <div className="h-4 w-40 bg-bg rounded" />
+                    <div className="h-3 w-56 bg-bg rounded" />
+                    <div className="h-6 w-24 bg-bg rounded" />
+                  </div>
+                ))}
+              </div>
+            ) : filteredToday.length === 0 ? (
+              <div className="px-4 py-6 text-center text-muted">
+                No attendance records yet.
+              </div>
+            ) : (
+              filteredToday.map((a) => {
+                const isIn = !!a.firstPunchIn && !a.lastPunchOut;
+                const elapsed = a.firstPunchIn
+                  ? isIn
+                    ? now - new Date(a.firstPunchIn).getTime()
+                    : new Date(a.lastPunchOut || 0).getTime() -
+                      new Date(a.firstPunchIn).getTime()
+                  : 0;
+                return (
+                  <div key={a.employee.id} className="p-4">
+                    <div className="flex items-center justify-between">
+                      <div className="font-medium">{a.employee.name}</div>
+                      <StatusBadge inOffice={isIn} />
+                    </div>
+                    <div className="mt-2 grid grid-cols-2 gap-2 text-sm">
+                      <div className="text-muted">First In</div>
+                      <div>{formatTime(a.firstPunchIn)}</div>
+                      <div className="text-muted">Last Out</div>
+                      <div>{formatTime(a.lastPunchOut)}</div>
+                      <div className="text-muted">Elapsed</div>
+                      <div>{a.firstPunchIn ? formatElapsed(elapsed) : "-"}</div>
+                    </div>
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </section>
+      ) : (
+        <section className="rounded-lg border border-border bg-surface shadow-sm overflow-hidden">
+          <div className="border-b border-border px-4 py-3 flex items-center justify-between">
+            <div className="text-sm text-muted">
+              {monthLoading
+                ? "Loading…"
+                : `${filteredMonth.length} record${
+                    filteredMonth.length === 1 ? "" : "s"
+                  }`}
+            </div>
+          </div>
+          <div className="hidden md:block">
+            <table className="w-full text-sm">
+              <thead className="bg-bg">
+                <tr className="text-left">
+                  <Th>Date</Th>
+                  <Th>Name</Th>
+                  <Th>First In</Th>
+                  <Th>Last Out</Th>
+                </tr>
+              </thead>
+              <tbody>
+                {monthLoading ? (
+                  <SkeletonRows rows={6} cols={4} />
+                ) : filteredMonth.length === 0 ? (
+                  <tr>
+                    <td colSpan={4} className="px-4 py-6 text-center text-muted">
+                      No attendance records yet.
+                    </td>
+                  </tr>
+                ) : (
+                  filteredMonth.map((a) => (
                     <tr
-                      key={a.employee.id}
+                      key={a.employee.id + a.date}
                       className="border-t border-border/70"
                     >
+                      <Td>{formatDate(a.date)}</Td>
                       <Td className="font-medium">{a.employee.name}</Td>
                       <Td>{formatTime(a.firstPunchIn)}</Td>
                       <Td>{formatTime(a.lastPunchOut)}</Td>
-                      <Td>
-                        <StatusBadge inOffice={isIn} />
-                      </Td>
-                      <Td>{a.firstPunchIn ? formatElapsed(elapsed) : "-"}</Td>
                     </tr>
-                  );
-                })
-              )}
-            </tbody>
-          </table>
-        </div>
-
-        {/* Mobile cards */}
-        <div className="md:hidden divide-y divide-border">
-          {loading ? (
-            <div className="p-4 space-y-3">
-              {Array.from({ length: 5 }).map((_, i) => (
-                <div
-                  key={i}
-                  className="rounded-md border border-border p-3 animate-pulse space-y-2"
-                >
-                  <div className="h-4 w-40 bg-bg rounded" />
-                  <div className="h-3 w-56 bg-bg rounded" />
-                  <div className="h-6 w-24 bg-bg rounded" />
-                </div>
-              ))}
-            </div>
-          ) : filtered.length === 0 ? (
-            <div className="px-4 py-6 text-center text-muted">
-              No attendance records yet.
-            </div>
-          ) : (
-            filtered.map((a) => {
-              const isIn = !!a.firstPunchIn && !a.lastPunchOut;
-              const elapsed = a.firstPunchIn
-                ? isIn
-                  ? now - new Date(a.firstPunchIn).getTime()
-                  : new Date(a.lastPunchOut || 0).getTime() -
-                    new Date(a.firstPunchIn).getTime()
-                : 0;
-              return (
-                <div key={a.employee.id} className="p-4">
-                  <div className="flex items-center justify-between">
-                    <div className="font-medium">{a.employee.name}</div>
-                    <StatusBadge inOffice={isIn} />
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+          <div className="md:hidden divide-y divide-border">
+            {monthLoading ? (
+              <div className="p-4 space-y-3">
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <div
+                    key={i}
+                    className="rounded-md border border-border p-3 animate-pulse space-y-2"
+                  >
+                    <div className="h-4 w-40 bg-bg rounded" />
+                    <div className="h-3 w-56 bg-bg rounded" />
+                    <div className="h-6 w-24 bg-bg rounded" />
                   </div>
+                ))}
+              </div>
+            ) : filteredMonth.length === 0 ? (
+              <div className="px-4 py-6 text-center text-muted">
+                No attendance records yet.
+              </div>
+            ) : (
+              filteredMonth.map((a) => (
+                <div key={a.employee.id + a.date} className="p-4">
+                  <div className="font-medium">{a.employee.name}</div>
                   <div className="mt-2 grid grid-cols-2 gap-2 text-sm">
+                    <div className="text-muted">Date</div>
+                    <div>{formatDate(a.date)}</div>
                     <div className="text-muted">First In</div>
                     <div>{formatTime(a.firstPunchIn)}</div>
                     <div className="text-muted">Last Out</div>
                     <div>{formatTime(a.lastPunchOut)}</div>
-                    <div className="text-muted">Elapsed</div>
-                    <div>{a.firstPunchIn ? formatElapsed(elapsed) : "-"}</div>
                   </div>
                 </div>
-              );
-            })
-          )}
-        </div>
-      </section>
+              ))
+            )}
+          </div>
+        </section>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- provide /attendance/history and /attendance/company/history endpoints for historical records
- allow admin attendance page to switch to a month view and load monthly records

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build -w apps/api` *(fails: Missing script "build" in apps/api)*
- `npm run build -w apps/web` *(fails: Cannot find module 'lucide-react')*

------
https://chatgpt.com/codex/tasks/task_e_68ac4c5df5ac832b8767c0bb45381180