### PR TITLE
feat: allow employees to upload documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 *.log
 apps/**/dist
 apps/**/build
+apps/**/tsconfig.tsbuildinfo

--- a/apps/api/src/index.js
+++ b/apps/api/src/index.js
@@ -1,12 +1,14 @@
 const express = require('express');
 const cors = require('cors');
 const cookieParser = require('cookie-parser');
+const path = require('path');
 const { connectDB } = require('./config');
 
 const app = express();
 app.use(express.json());
 app.use(cookieParser());
 app.use(cors({ origin: process.env.CLIENT_ORIGIN, credentials: true }));
+app.use('/uploads', express.static(path.join(__dirname, '../uploads')));
 
 app.get('/', (req, res) => res.json({ ok: true }));
 app.use('/auth', require('./routes/auth'));
@@ -14,6 +16,7 @@ app.use('/seed', require('./routes/seed'));
 app.use('/companies', require('./routes/companies'));
 app.use('/attendance', require('./routes/attendance'));
 app.use('/leaves', require('./routes/leaves'));
+app.use('/documents', require('./routes/documents'));
 
 connectDB().then(() => {
   const port = process.env.PORT || 4000;

--- a/apps/api/src/routes/documents.js
+++ b/apps/api/src/routes/documents.js
@@ -1,0 +1,41 @@
+const router = require("express").Router();
+const multer = require("multer");
+const path = require("path");
+const Employee = require("../models/Employee");
+const { auth } = require("../middleware/auth");
+const { requirePrimary } = require("../middleware/roles");
+
+const upload = multer({ dest: path.join(__dirname, "../../uploads") });
+
+// Employee: list own documents
+router.get("/", auth, async (req, res) => {
+  const emp = await Employee.findById(req.employee.id).select("documents").lean();
+  res.json({ documents: emp?.documents || [] });
+});
+
+// Employee: upload documents
+router.post("/", auth, upload.array("documents"), async (req, res) => {
+  const docs = (req.files || []).map((f) => f.filename);
+  const emp = await Employee.findByIdAndUpdate(
+    req.employee.id,
+    { $push: { documents: { $each: docs } } },
+    { new: true }
+  ).select("documents");
+  res.json({ documents: emp.documents });
+});
+
+// Admin: view documents of an employee
+router.get(
+  "/:id",
+  auth,
+  requirePrimary(["ADMIN", "SUPERADMIN"]),
+  async (req, res) => {
+    const emp = await Employee.findById(req.params.id)
+      .select("name email documents")
+      .lean();
+    if (!emp) return res.status(404).json({ error: "Not found" });
+    res.json({ employee: { id: emp._id, name: emp.name, email: emp.email, documents: emp.documents } });
+  }
+);
+
+module.exports = router;

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -18,6 +18,8 @@ import LeaveRequests from './pages/admin/LeaveRequests';
 import EmployeeDash from './pages/employee/Dashboard';
 import AttendanceRecords from './pages/employee/AttendanceRecords';
 import LeaveRequest from './pages/employee/LeaveRequest';
+import Documents from './pages/employee/Documents';
+import EmployeeDetails from './pages/admin/EmployeeDetails';
 
 export default function App() {
   return (
@@ -52,6 +54,7 @@ export default function App() {
         <Route index element={<AdminDash />} />
         <Route path="employees/add" element={<AddEmployee />} />
         <Route path="employees" element={<EmployeeList />} />
+        <Route path="employees/:id" element={<EmployeeDetails />} />
         <Route path="attendances" element={<AttendanceList />} />
         <Route path="leaves" element={<LeaveRequests />} />
       </Route>
@@ -69,6 +72,7 @@ export default function App() {
         <Route index element={<EmployeeDash />} />
         <Route path="attendance" element={<AttendanceRecords />} />
         <Route path="leave" element={<LeaveRequest />} />
+        <Route path="documents" element={<Documents />} />
       </Route>
 
       <Route path="*" element={<Navigate to="/login" replace />} />

--- a/apps/web/src/layouts/AdminLayout.tsx
+++ b/apps/web/src/layouts/AdminLayout.tsx
@@ -33,6 +33,7 @@ export default function AdminLayout() {
   const title = useMemo(() => {
     if (pathname === "/admin") return "Dashboard";
     if (pathname.startsWith("/admin/employees/add")) return "Add Employee";
+    if (pathname.startsWith("/admin/employees/")) return "Employee Details";
     if (pathname.startsWith("/admin/employees")) return "Employee List";
     if (pathname.startsWith("/admin/attendances")) return "Attendances";
     if (pathname.startsWith("/admin/leaves")) return "Leave Requests";

--- a/apps/web/src/layouts/EmployeeLayout.tsx
+++ b/apps/web/src/layouts/EmployeeLayout.tsx
@@ -9,6 +9,7 @@ import {
   Menu,
   X,
   User,
+  FileText,
 } from "lucide-react";
 
 export default function EmployeeLayout() {
@@ -24,12 +25,14 @@ export default function EmployeeLayout() {
     { to: "/app", label: "Dashboard", icon: Home },
     { to: "/app/attendance", label: "Attendance", icon: Clock8 },
     { to: "/app/leave", label: "Leave", icon: CalendarCheck2 },
+    { to: "/app/documents", label: "Documents", icon: FileText },
   ];
 
   const title = useMemo(() => {
     if (pathname === "/app") return "Dashboard";
     if (pathname.startsWith("/app/attendance")) return "Attendance";
     if (pathname.startsWith("/app/leave")) return "Leave";
+    if (pathname.startsWith("/app/documents")) return "Documents";
     return "Employee";
   }, [pathname]);
 

--- a/apps/web/src/pages/admin/EmployeeDetails.tsx
+++ b/apps/web/src/pages/admin/EmployeeDetails.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { api } from "../../lib/api";
+
+type Employee = {
+  id: string;
+  name: string;
+  email: string;
+  documents: string[];
+};
+
+export default function EmployeeDetails() {
+  const { id } = useParams();
+  const [employee, setEmployee] = useState<Employee | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        setLoading(true);
+        const res = await api.get(`/documents/${id}`);
+        setEmployee(res.data.employee);
+      } catch (e: any) {
+        setErr(e?.response?.data?.error || "Failed to load employee");
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [id]);
+
+  const base = import.meta.env.VITE_API_URL || "http://localhost:4000";
+
+  if (loading) return <div>Loading…</div>;
+  if (err) return <div className="text-error">{err}</div>;
+  if (!employee) return <div>Not found</div>;
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-3xl font-bold">{employee.name}</h2>
+        <p className="text-sm text-muted">{employee.email}</p>
+      </div>
+      <section>
+        <h3 className="font-semibold mb-2">Documents</h3>
+        {employee.documents?.length === 0 ? (
+          <div className="text-sm text-muted">No documents uploaded.</div>
+        ) : (
+          <ul className="list-disc pl-6 space-y-1">
+            {employee.documents.map((d) => (
+              <li key={d}>
+                <a
+                  href={`${base}/uploads/${d}`}
+                  target="_blank"
+                  className="text-primary underline"
+                >
+                  {d}
+                </a>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}
+

--- a/apps/web/src/pages/admin/EmployeeList.tsx
+++ b/apps/web/src/pages/admin/EmployeeList.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 import { api } from "../../lib/api";
 
 type CompanyEmployee = {
@@ -105,7 +106,14 @@ export default function EmployeeList() {
               ) : (
                 filtered.map((u) => (
                   <tr key={u.id} className="border-t border-border/70">
-                    <Td>{u.name}</Td>
+                    <Td>
+                      <Link
+                        to={`/admin/employees/${u.id}`}
+                        className="text-primary underline"
+                      >
+                        {u.name}
+                      </Link>
+                    </Td>
                     <Td>
                       <span className="truncate inline-block max-w-[28rem] align-middle">
                         {u.email}
@@ -143,7 +151,14 @@ export default function EmployeeList() {
           ) : (
             filtered.map((u) => (
               <div key={u.id} className="p-4">
-                <div className="font-medium">{u.name}</div>
+                <div className="font-medium">
+                  <Link
+                    to={`/admin/employees/${u.id}`}
+                    className="text-primary underline"
+                  >
+                    {u.name}
+                  </Link>
+                </div>
                 <div className="text-sm text-muted">{u.email}</div>
                 <div className="mt-2">
                   <RoleBadge role={u.subRoles?.[0]} />

--- a/apps/web/src/pages/employee/Documents.tsx
+++ b/apps/web/src/pages/employee/Documents.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from "react";
+import { api } from "../../lib/api";
+
+export default function Documents() {
+  const [docs, setDocs] = useState<string[]>([]);
+  const [files, setFiles] = useState<FileList | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+  const [ok, setOk] = useState<string | null>(null);
+
+  async function load() {
+    try {
+      setLoading(true);
+      const res = await api.get("/documents");
+      setDocs(res.data.documents || []);
+    } catch (e: any) {
+      setErr(e?.response?.data?.error || "Failed to load documents");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function uploadDocs(e: React.FormEvent) {
+    e.preventDefault();
+    if (!files || files.length === 0) return;
+    const fd = new FormData();
+    Array.from(files).forEach((f) => fd.append("documents", f));
+    try {
+      setErr(null);
+      setOk(null);
+      const res = await api.post("/documents", fd, {
+        headers: { "Content-Type": "multipart/form-data" },
+      });
+      setDocs(res.data.documents || []);
+      setFiles(null);
+      (e.target as HTMLFormElement).reset();
+      setOk("Uploaded");
+    } catch (e: any) {
+      setErr(e?.response?.data?.error || "Upload failed");
+    }
+  }
+
+  const base = import.meta.env.VITE_API_URL || "http://localhost:4000";
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-3xl font-bold">Documents</h2>
+        <p className="text-sm text-muted">Upload and view your documents.</p>
+      </div>
+
+      {err && (
+        <div className="rounded-md border border-error/20 bg-red-50 px-4 py-2 text-sm text-error">
+          {err}
+        </div>
+      )}
+      {ok && (
+        <div className="rounded-md border border-success/20 bg-green-50 px-4 py-2 text-sm text-success">
+          {ok}
+        </div>
+      )}
+
+      <form onSubmit={uploadDocs} className="space-y-3">
+        <input
+          type="file"
+          multiple
+          onChange={(e) => setFiles(e.target.files)}
+        />
+        <button
+          type="submit"
+          className="rounded-md bg-primary px-4 py-2 text-white"
+        >
+          Upload
+        </button>
+      </form>
+
+      <section>
+        <h3 className="font-semibold mb-2">Uploaded</h3>
+        {loading ? (
+          <div className="text-sm text-muted">Loading…</div>
+        ) : docs.length === 0 ? (
+          <div className="text-sm text-muted">No documents uploaded.</div>
+        ) : (
+          <ul className="list-disc pl-6 space-y-1">
+            {docs.map((d) => (
+              <li key={d}>
+                <a
+                  href={`${base}/uploads/${d}`}
+                  target="_blank"
+                  className="text-primary underline"
+                >
+                  {d}
+                </a>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- enable API endpoints for uploading and retrieving employee documents
- add employee documents page and sidebar link
- allow admins to view an employee's documents

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build -w apps/web`
- `npm run build -w apps/api` *(fails: Missing script "build")*

------
https://chatgpt.com/codex/tasks/task_e_68ad37922434832b861bf89430be066a