### PR TITLE
Add reporting hierarchy and leave approval workflow

### DIFF
--- a/apps/api/src/models/Employee.js
+++ b/apps/api/src/models/Employee.js
@@ -10,7 +10,14 @@ const EmployeeSchema = new mongoose.Schema(
     company: { type: mongoose.Schema.Types.ObjectId, ref: 'Company' },
     address: { type: String },
     phone: { type: String },
-    documents: { type: [String], default: [] }
+    documents: { type: [String], default: [] },
+    reportingPerson: { type: mongoose.Schema.Types.ObjectId, ref: 'Employee' },
+    leaveBalances: {
+      casual: { type: Number, default: 0 },
+      paid: { type: Number, default: 0 },
+      unpaid: { type: Number, default: 0 },
+      sick: { type: Number, default: 0 }
+    }
   },
   { timestamps: true }
 );

--- a/apps/api/src/models/Leave.js
+++ b/apps/api/src/models/Leave.js
@@ -4,6 +4,12 @@ const LeaveSchema = new mongoose.Schema(
   {
     employee: { type: mongoose.Schema.Types.ObjectId, ref: 'Employee', required: true },
     company: { type: mongoose.Schema.Types.ObjectId, ref: 'Company', required: true },
+    approver: { type: mongoose.Schema.Types.ObjectId, ref: 'Employee' },
+    type: {
+      type: String,
+      enum: ['CASUAL', 'PAID', 'UNPAID', 'SICK'],
+      required: true,
+    },
     startDate: { type: Date, required: true },
     endDate: { type: Date, required: true },
     reason: { type: String },

--- a/apps/api/src/routes/leaves.js
+++ b/apps/api/src/routes/leaves.js
@@ -1,18 +1,24 @@
 const router = require('express').Router();
 const Leave = require('../models/Leave');
+const Employee = require('../models/Employee');
 const { auth } = require('../middleware/auth');
 const { requirePrimary } = require('../middleware/roles');
 
 // Employee creates a leave request
 router.post('/', auth, async (req, res) => {
-  const { startDate, endDate, reason } = req.body;
+  const { startDate, endDate, reason, type } = req.body;
   try {
+    const emp = await Employee.findById(req.employee.id);
+    if (!emp) return res.status(400).json({ error: 'Employee not found' });
+    if (!type) return res.status(400).json({ error: 'Missing type' });
     const leave = await Leave.create({
-      employee: req.employee.id,
-      company: req.employee.company,
+      employee: emp._id,
+      company: emp.company,
+      approver: emp.reportingPerson,
+      type,
       startDate,
       endDate,
-      reason
+      reason,
     });
     res.json({ leave });
   } catch (err) {
@@ -28,6 +34,15 @@ router.get('/', auth, async (req, res) => {
   res.json({ leaves });
 });
 
+// Reporting person views assigned leave requests
+router.get('/assigned', auth, async (req, res) => {
+  const leaves = await Leave.find({ approver: req.employee.id })
+    .populate('employee', 'name')
+    .sort({ createdAt: -1 })
+    .lean();
+  res.json({ leaves });
+});
+
 // Admin views company leave requests
 router.get('/company', auth, requirePrimary(['ADMIN', 'SUPERADMIN']), async (req, res) => {
   const leaves = await Leave.find({ company: req.employee.company })
@@ -37,25 +52,43 @@ router.get('/company', auth, requirePrimary(['ADMIN', 'SUPERADMIN']), async (req
   res.json({ leaves });
 });
 
-// Admin approves a leave
-router.post('/:id/approve', auth, requirePrimary(['ADMIN', 'SUPERADMIN']), async (req, res) => {
-  const leave = await Leave.findByIdAndUpdate(
-    req.params.id,
-    { status: 'APPROVED', adminMessage: req.body.message },
-    { new: true }
-  );
+// Approve a leave
+router.post('/:id/approve', auth, async (req, res) => {
+  const leave = await Leave.findById(req.params.id);
   if (!leave) return res.status(404).json({ error: 'Not found' });
+  const isAdmin = ['ADMIN', 'SUPERADMIN'].includes(req.employee.primaryRole);
+  if (
+    String(leave.approver) !== String(req.employee.id) &&
+    !isAdmin
+  )
+    return res.status(403).json({ error: 'Forbidden' });
+  const employee = await Employee.findById(leave.employee);
+  const days = Math.round((leave.endDate - leave.startDate) / 86400000) + 1;
+  const key = leave.type.toLowerCase();
+  const remaining = employee.leaveBalances?.[key] || 0;
+  if (remaining < days)
+    return res.status(400).json({ error: 'Insufficient leave balance' });
+  employee.leaveBalances[key] = remaining - days;
+  await employee.save();
+  leave.status = 'APPROVED';
+  leave.adminMessage = req.body.message;
+  await leave.save();
   res.json({ leave });
 });
 
-// Admin rejects a leave
-router.post('/:id/reject', auth, requirePrimary(['ADMIN', 'SUPERADMIN']), async (req, res) => {
-  const leave = await Leave.findByIdAndUpdate(
-    req.params.id,
-    { status: 'REJECTED', adminMessage: req.body.message },
-    { new: true }
-  );
+// Reject a leave
+router.post('/:id/reject', auth, async (req, res) => {
+  const leave = await Leave.findById(req.params.id);
   if (!leave) return res.status(404).json({ error: 'Not found' });
+  const isAdmin = ['ADMIN', 'SUPERADMIN'].includes(req.employee.primaryRole);
+  if (
+    String(leave.approver) !== String(req.employee.id) &&
+    !isAdmin
+  )
+    return res.status(403).json({ error: 'Forbidden' });
+  leave.status = 'REJECTED';
+  leave.adminMessage = req.body.message;
+  await leave.save();
   res.json({ leave });
 });
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -19,6 +19,7 @@ import EmployeeDash from './pages/employee/Dashboard';
 import AttendanceRecords from './pages/employee/AttendanceRecords';
 import LeaveRequest from './pages/employee/LeaveRequest';
 import Documents from './pages/employee/Documents';
+import LeaveApprovals from './pages/employee/LeaveApprovals';
 import EmployeeDetails from './pages/admin/EmployeeDetails';
 
 export default function App() {
@@ -72,6 +73,7 @@ export default function App() {
         <Route index element={<EmployeeDash />} />
         <Route path="attendance" element={<AttendanceRecords />} />
         <Route path="leave" element={<LeaveRequest />} />
+        <Route path="approvals" element={<LeaveApprovals />} />
         <Route path="documents" element={<Documents />} />
       </Route>
 

--- a/apps/web/src/layouts/EmployeeLayout.tsx
+++ b/apps/web/src/layouts/EmployeeLayout.tsx
@@ -10,6 +10,7 @@ import {
   X,
   User,
   FileText,
+  ClipboardList,
 } from "lucide-react";
 
 export default function EmployeeLayout() {
@@ -25,6 +26,7 @@ export default function EmployeeLayout() {
     { to: "/app", label: "Dashboard", icon: Home },
     { to: "/app/attendance", label: "Attendance", icon: Clock8 },
     { to: "/app/leave", label: "Leave", icon: CalendarCheck2 },
+    { to: "/app/approvals", label: "Approvals", icon: ClipboardList },
     { to: "/app/documents", label: "Documents", icon: FileText },
   ];
 
@@ -32,6 +34,7 @@ export default function EmployeeLayout() {
     if (pathname === "/app") return "Dashboard";
     if (pathname.startsWith("/app/attendance")) return "Attendance";
     if (pathname.startsWith("/app/leave")) return "Leave";
+    if (pathname.startsWith("/app/approvals")) return "Leave Approvals";
     if (pathname.startsWith("/app/documents")) return "Documents";
     return "Employee";
   }, [pathname]);

--- a/apps/web/src/pages/admin/AddEmployee.tsx
+++ b/apps/web/src/pages/admin/AddEmployee.tsx
@@ -1,4 +1,4 @@
-import { useState, FormEvent, ChangeEvent, useMemo } from "react";
+import { useState, FormEvent, ChangeEvent, useMemo, useEffect } from "react";
 import { api } from "../../lib/api";
 
 type FormState = {
@@ -8,6 +8,11 @@ type FormState = {
   role: "hr" | "manager" | "developer";
   address: string;
   phone: string;
+  reportingPerson: string;
+  casualLeaves: string;
+  paidLeaves: string;
+  unpaidLeaves: string;
+  sickLeaves: string;
 };
 
 export default function AddEmployee() {
@@ -18,11 +23,17 @@ export default function AddEmployee() {
     role: "hr",
     address: "",
     phone: "",
+    reportingPerson: "",
+    casualLeaves: "0",
+    paidLeaves: "0",
+    unpaidLeaves: "0",
+    sickLeaves: "0",
   });
   const [docs, setDocs] = useState<FileList | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [ok, setOk] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
+  const [employees, setEmployees] = useState<{ id: string; name: string }[]>([]);
 
   const canSubmit = useMemo(() => {
     return (
@@ -38,6 +49,17 @@ export default function AddEmployee() {
   function onChange<K extends keyof FormState>(key: K, value: FormState[K]) {
     setForm((prev) => ({ ...prev, [key]: value }));
   }
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await api.get("/companies/employees");
+        setEmployees(res.data.employees || []);
+      } catch {
+        // ignore
+      }
+    })();
+  }, []);
 
   async function submit(e: FormEvent) {
     e.preventDefault();
@@ -59,6 +81,11 @@ export default function AddEmployee() {
         role: "hr",
         address: "",
         phone: "",
+        reportingPerson: "",
+        casualLeaves: "0",
+        paidLeaves: "0",
+        unpaidLeaves: "0",
+        sickLeaves: "0",
       });
       setDocs(null);
       setOk("Employee added");
@@ -146,6 +173,23 @@ export default function AddEmployee() {
           </div>
 
           <div className="grid gap-4 md:grid-cols-2">
+            <Field label="Reporting Person">
+              <select
+                className="w-full rounded-md border border-border bg-surface px-3 py-2 outline-none focus:ring-2 focus:ring-primary"
+                value={form.reportingPerson}
+                onChange={(e) => onChange("reportingPerson", e.target.value)}
+              >
+                <option value="">None</option>
+                {employees.map((e) => (
+                  <option key={e.id} value={e.id}>
+                    {e.name}
+                  </option>
+                ))}
+              </select>
+            </Field>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
             <Field label="Address">
               <input
                 className="w-full rounded-md border border-border bg-surface px-3 py-2 outline-none focus:ring-2 focus:ring-primary"
@@ -160,6 +204,41 @@ export default function AddEmployee() {
                 placeholder="+91 98765 43210"
                 value={form.phone}
                 onChange={(e) => onChange("phone", e.target.value)}
+              />
+            </Field>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-4">
+            <Field label="Casual Leaves">
+              <input
+                type="number"
+                className="w-full rounded-md border border-border bg-surface px-3 py-2 outline-none focus:ring-2 focus:ring-primary"
+                value={form.casualLeaves}
+                onChange={(e) => onChange("casualLeaves", e.target.value)}
+              />
+            </Field>
+            <Field label="Paid Leaves">
+              <input
+                type="number"
+                className="w-full rounded-md border border-border bg-surface px-3 py-2 outline-none focus:ring-2 focus:ring-primary"
+                value={form.paidLeaves}
+                onChange={(e) => onChange("paidLeaves", e.target.value)}
+              />
+            </Field>
+            <Field label="Unpaid Leaves">
+              <input
+                type="number"
+                className="w-full rounded-md border border-border bg-surface px-3 py-2 outline-none focus:ring-2 focus:ring-primary"
+                value={form.unpaidLeaves}
+                onChange={(e) => onChange("unpaidLeaves", e.target.value)}
+              />
+            </Field>
+            <Field label="Sick Leaves">
+              <input
+                type="number"
+                className="w-full rounded-md border border-border bg-surface px-3 py-2 outline-none focus:ring-2 focus:ring-primary"
+                value={form.sickLeaves}
+                onChange={(e) => onChange("sickLeaves", e.target.value)}
               />
             </Field>
           </div>

--- a/apps/web/src/pages/admin/LeaveRequests.tsx
+++ b/apps/web/src/pages/admin/LeaveRequests.tsx
@@ -6,6 +6,7 @@ type Leave = {
   employee: { _id: string; name: string };
   startDate: string;
   endDate: string;
+  type: "CASUAL" | "PAID" | "UNPAID" | "SICK";
   reason?: string;
   status: "PENDING" | "APPROVED" | "REJECTED";
   adminMessage?: string;
@@ -127,6 +128,7 @@ export default function LeaveRequests() {
                 <Th>Employee</Th>
                 <Th>Start</Th>
                 <Th>End</Th>
+                <Th>Type</Th>
                 <Th>Reason</Th>
                 <Th>Status</Th>
                 <Th>Actions</Th>
@@ -134,10 +136,10 @@ export default function LeaveRequests() {
             </thead>
             <tbody>
               {loading ? (
-                <SkeletonRows rows={6} cols={6} />
+                <SkeletonRows rows={6} cols={7} />
               ) : filtered.length === 0 ? (
                 <tr>
-                  <td colSpan={6} className="px-4 py-6 text-center text-muted">
+                  <td colSpan={7} className="px-4 py-6 text-center text-muted">
                     No leave requests.
                   </td>
                 </tr>
@@ -147,6 +149,7 @@ export default function LeaveRequests() {
                     <Td className="font-medium">{l.employee.name}</Td>
                     <Td>{new Date(l.startDate).toLocaleDateString()}</Td>
                     <Td>{new Date(l.endDate).toLocaleDateString()}</Td>
+                    <Td>{l.type}</Td>
                     <Td>
                       <span
                         title={l.reason || ""}
@@ -221,6 +224,8 @@ export default function LeaveRequests() {
                   <div>{new Date(l.startDate).toLocaleDateString()}</div>
                   <div className="text-muted">End</div>
                   <div>{new Date(l.endDate).toLocaleDateString()}</div>
+                  <div className="text-muted">Type</div>
+                  <div>{l.type}</div>
                   <div className="text-muted">Reason</div>
                   <div className="col-span-1">{l.reason || "-"}</div>
                 </div>

--- a/apps/web/src/pages/employee/LeaveApprovals.tsx
+++ b/apps/web/src/pages/employee/LeaveApprovals.tsx
@@ -1,0 +1,203 @@
+import { useEffect, useState } from "react";
+import { api } from "../../lib/api";
+
+type Leave = {
+  _id: string;
+  employee: { _id: string; name: string };
+  startDate: string;
+  endDate: string;
+  type: "CASUAL" | "PAID" | "UNPAID" | "SICK";
+  status: "PENDING" | "APPROVED" | "REJECTED";
+  adminMessage?: string;
+};
+
+export default function LeaveApprovals() {
+  const [rows, setRows] = useState<Leave[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+  const [modal, setModal] = useState<{ id: string; action: "approve" | "reject" } | null>(null);
+  const [message, setMessage] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  async function load() {
+    try {
+      setLoading(true);
+      setErr(null);
+      const res = await api.get("/leaves/assigned");
+      setRows(res.data.leaves || []);
+    } catch (e: any) {
+      setErr(e?.response?.data?.error || "Failed to load leaves");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function confirmAction() {
+    if (!modal) return;
+    try {
+      setSubmitting(true);
+      await api.post(`/leaves/${modal.id}/${modal.action}`, { message });
+      setModal(null);
+      setMessage("");
+      load();
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h2 className="text-3xl font-bold">Leave Approvals</h2>
+        <p className="text-sm text-muted">Review leave requests from your team.</p>
+      </div>
+
+      {err && (
+        <div className="rounded-md border border-error/20 bg-red-50 px-4 py-2 text-sm text-error">{err}</div>
+      )}
+
+      <section className="rounded-lg border border-border bg-surface shadow-sm overflow-hidden">
+        <div className="border-b border-border px-4 py-3 text-sm text-muted">
+          {loading ? "Loading…" : `${rows.length} request${rows.length === 1 ? "" : "s"}`}
+        </div>
+        <table className="w-full text-sm">
+          <thead className="bg-bg">
+            <tr className="text-left">
+              <Th>Employee</Th>
+              <Th>Start</Th>
+              <Th>End</Th>
+              <Th>Type</Th>
+              <Th>Status</Th>
+              <Th>Actions</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading ? (
+              <SkeletonRows rows={6} cols={6} />
+            ) : rows.length === 0 ? (
+              <tr>
+                <td colSpan={6} className="px-4 py-6 text-center text-muted">
+                  No leave requests.
+                </td>
+              </tr>
+            ) : (
+              rows.map((l) => (
+                <tr key={l._id} className="border-t border-border/70">
+                  <Td>{l.employee?.name || "-"}</Td>
+                  <Td>{new Date(l.startDate).toLocaleDateString()}</Td>
+                  <Td>{new Date(l.endDate).toLocaleDateString()}</Td>
+                  <Td>{l.type}</Td>
+                  <Td>
+                    <StatusBadge status={l.status} />
+                  </Td>
+                  <Td>
+                    {l.status === "PENDING" ? (
+                      <div className="flex gap-2">
+                        <button
+                          className="rounded-md bg-secondary px-3 py-1 text-white"
+                          onClick={() => setModal({ id: l._id, action: "approve" })}
+                        >
+                          Approve
+                        </button>
+                        <button
+                          className="rounded-md bg-accent px-3 py-1 text-white"
+                          onClick={() => setModal({ id: l._id, action: "reject" })}
+                        >
+                          Reject
+                        </button>
+                      </div>
+                    ) : (
+                      <span>{l.adminMessage || "-"}</span>
+                    )}
+                  </Td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </section>
+
+      {modal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div className="absolute inset-0 bg-black/40" onClick={() => setModal(null)} />
+          <div className="relative w-full max-w-md rounded-lg border border-border bg-surface p-5 shadow-lg">
+            <h4 className="text-lg font-semibold mb-2">
+              {modal.action === "approve" ? "Approve Leave" : "Reject Leave"}
+            </h4>
+            <p className="text-sm text-muted mb-3">Add a short message (optional).</p>
+            <textarea
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              rows={3}
+              className="w-full rounded-md border border-border bg-surface px-3 py-2 outline-none focus:ring-2 focus:ring-primary"
+              placeholder="Message"
+            />
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                className="rounded-md border border-border px-4 py-2"
+                onClick={() => setModal(null)}
+                disabled={submitting}
+              >
+                Cancel
+              </button>
+              <button
+                className={`rounded-md px-4 py-2 text-white ${
+                  modal.action === "approve" ? "bg-secondary" : "bg-accent"
+                } disabled:opacity-60`}
+                onClick={confirmAction}
+                disabled={submitting}
+              >
+                {submitting ? "Saving…" : modal.action === "approve" ? "Approve" : "Reject"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Th({ children }: { children: React.ReactNode }) {
+  return (
+    <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-muted">
+      {children}
+    </th>
+  );
+}
+
+function Td({ children }: { children: React.ReactNode }) {
+  return <td className="px-4 py-3 align-middle">{children}</td>;
+}
+
+function SkeletonRows({ rows, cols }: { rows: number; cols: number }) {
+  return (
+    <>
+      {Array.from({ length: rows }).map((_, r) => (
+        <tr key={r} className="border-t border-border/70">
+          {Array.from({ length: cols }).map((__, c) => (
+            <td key={c} className="px-4 py-3">
+              <div className="h-4 w-40 bg-bg rounded animate-pulse" />
+            </td>
+          ))}
+        </tr>
+      ))}
+    </>
+  );
+}
+
+function StatusBadge({ status }: { status: Leave["status"] }) {
+  const map: Record<Leave["status"], string> = {
+    PENDING: "bg-accent/10 text-accent",
+    APPROVED: "bg-secondary/10 text-secondary",
+    REJECTED: "bg-error/10 text-error",
+  };
+  return (
+    <span className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium ${map[status]}`}>
+      {status.charAt(0) + status.slice(1).toLowerCase()}
+    </span>
+  );
+}

--- a/apps/web/src/pages/employee/LeaveRequest.tsx
+++ b/apps/web/src/pages/employee/LeaveRequest.tsx
@@ -5,12 +5,18 @@ type Leave = {
   _id: string;
   startDate: string;
   endDate: string;
+  type: "CASUAL" | "PAID" | "UNPAID" | "SICK";
   reason?: string;
   status: "PENDING" | "APPROVED" | "REJECTED";
   adminMessage?: string;
 };
 
-type FormState = { startDate: string; endDate: string; reason: string };
+type FormState = {
+  startDate: string;
+  endDate: string;
+  reason: string;
+  type: "CASUAL" | "PAID" | "UNPAID" | "SICK";
+};
 
 function daysBetween(a: string, b: string) {
   if (!a || !b) return 0;
@@ -24,6 +30,7 @@ export default function LeaveRequest() {
     startDate: "",
     endDate: "",
     reason: "",
+    type: "CASUAL",
   });
   const [leaves, setLeaves] = useState<Leave[]>([]);
   const [loading, setLoading] = useState(true);
@@ -63,7 +70,7 @@ export default function LeaveRequest() {
     try {
       setSending(true);
       await api.post("/leaves", form);
-      setForm({ startDate: "", endDate: "", reason: "" });
+      setForm({ startDate: "", endDate: "", reason: "", type: "CASUAL" });
       setOk("Leave request submitted");
       await load();
     } catch (e: any) {
@@ -101,7 +108,22 @@ export default function LeaveRequest() {
           <h3 className="text-lg font-semibold">New Request</h3>
         </div>
         <form onSubmit={submit} className="px-6 py-5 space-y-4">
-          <div className="grid gap-4 md:grid-cols-2">
+          <div className="grid gap-4 md:grid-cols-3">
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Type</label>
+              <select
+                className="w-full rounded-md border border-border bg-surface px-3 py-2 outline-none focus:ring-2 focus:ring-primary"
+                value={form.type}
+                onChange={(e) =>
+                  setForm({ ...form, type: e.target.value as FormState["type"] })
+                }
+              >
+                <option value="CASUAL">Casual</option>
+                <option value="PAID">Paid</option>
+                <option value="UNPAID">Unpaid</option>
+                <option value="SICK">Sick</option>
+              </select>
+            </div>
             <div className="space-y-2">
               <label className="text-sm font-medium">Start date</label>
               <input
@@ -154,7 +176,7 @@ export default function LeaveRequest() {
               type="button"
               className="rounded-md border border-border px-3 py-2"
               onClick={() =>
-                setForm({ startDate: "", endDate: "", reason: "" })
+                setForm({ startDate: "", endDate: "", reason: "", type: "CASUAL" })
               }
               disabled={sending}
             >
@@ -186,16 +208,17 @@ export default function LeaveRequest() {
                 <Th>Start</Th>
                 <Th>End</Th>
                 <Th>Days</Th>
+                <Th>Type</Th>
                 <Th>Status</Th>
                 <Th>Message</Th>
               </tr>
             </thead>
             <tbody>
               {loading ? (
-                <SkeletonRows rows={6} cols={5} />
+                <SkeletonRows rows={6} cols={6} />
               ) : leaves.length === 0 ? (
                 <tr>
-                  <td colSpan={5} className="px-4 py-6 text-center text-muted">
+                  <td colSpan={6} className="px-4 py-6 text-center text-muted">
                     No leave requests yet.
                   </td>
                 </tr>
@@ -210,6 +233,7 @@ export default function LeaveRequest() {
                       <Td>{new Date(l.startDate).toLocaleDateString()}</Td>
                       <Td>{new Date(l.endDate).toLocaleDateString()}</Td>
                       <Td>{daysBetween(l.startDate, l.endDate)}</Td>
+                      <Td>{l.type}</Td>
                       <Td>
                         <StatusBadge status={l.status as Leave["status"]} />
                       </Td>
@@ -263,6 +287,8 @@ export default function LeaveRequest() {
                   <div className="mt-2 grid grid-cols-2 gap-2 text-sm">
                     <div className="text-muted">Days</div>
                     <div>{daysBetween(l.startDate, l.endDate)}</div>
+                    <div className="text-muted">Type</div>
+                    <div>{l.type}</div>
                     <div className="text-muted">Message</div>
                     <div className="col-span-1">{l.adminMessage || "-"}</div>
                   </div>


### PR DESCRIPTION
## Summary
- track each employee's reporting person and leave balances, enabling configurable annual quotas
- extend leave model with types and approver, routing requests to managers and deducting balances on approval
- add UI for setting reporting managers and leave quotas, and new pages for leave type selection and manager approvals

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build -w apps/web` *(fails: Cannot find type definition file for 'vite/client')*


------
https://chatgpt.com/codex/tasks/task_e_68ad3b3996dc832bb1ea1bd7399dba1d