### PR TITLE
feat: add admin leave settings page

### DIFF
--- a/apps/api/src/models/Company.js
+++ b/apps/api/src/models/Company.js
@@ -3,7 +3,12 @@ const mongoose = require('mongoose');
 const CompanySchema = new mongoose.Schema(
   {
     name: { type: String, required: true },
-    admin: { type: mongoose.Schema.Types.ObjectId, ref: 'Employee' }
+    admin: { type: mongoose.Schema.Types.ObjectId, ref: 'Employee' },
+    leavePolicy: {
+      casual: { type: Number, default: 0 },
+      paid: { type: Number, default: 0 },
+      sick: { type: Number, default: 0 }
+    }
   },
   { timestamps: true }
 );

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -14,6 +14,7 @@ import AddEmployee from './pages/admin/AddEmployee';
 import EmployeeList from './pages/admin/EmployeeList';
 import AttendanceList from './pages/admin/AttendanceList';
 import LeaveRequests from './pages/admin/LeaveRequests';
+import LeaveSettings from './pages/admin/LeaveSettings';
 
 import EmployeeDash from './pages/employee/Dashboard';
 import AttendanceRecords from './pages/employee/AttendanceRecords';
@@ -57,6 +58,7 @@ export default function App() {
         <Route path="employees" element={<EmployeeList />} />
         <Route path="employees/:id" element={<EmployeeDetails />} />
         <Route path="attendances" element={<AttendanceList />} />
+        <Route path="leave-settings" element={<LeaveSettings />} />
         <Route path="leaves" element={<LeaveRequests />} />
       </Route>
 

--- a/apps/web/src/layouts/AdminLayout.tsx
+++ b/apps/web/src/layouts/AdminLayout.tsx
@@ -11,6 +11,7 @@ import {
   Menu,
   X,
   User,
+  Settings,
 } from "lucide-react";
 
 export default function AdminLayout() {
@@ -27,6 +28,7 @@ export default function AdminLayout() {
     { to: "/admin/employees/add", label: "Add Employee", icon: UserPlus },
     { to: "/admin/employees", label: "Employee List", icon: Users },
     { to: "/admin/attendances", label: "Attendances", icon: CalendarCheck2 },
+    { to: "/admin/leave-settings", label: "Leave Settings", icon: Settings },
     { to: "/admin/leaves", label: "Leave Requests", icon: ClipboardList },
   ];
 
@@ -36,6 +38,7 @@ export default function AdminLayout() {
     if (pathname.startsWith("/admin/employees/")) return "Employee Details";
     if (pathname.startsWith("/admin/employees")) return "Employee List";
     if (pathname.startsWith("/admin/attendances")) return "Attendances";
+    if (pathname.startsWith("/admin/leave-settings")) return "Leave Settings";
     if (pathname.startsWith("/admin/leaves")) return "Leave Requests";
     return "Admin";
   }, [pathname]);

--- a/apps/web/src/pages/admin/AddEmployee.tsx
+++ b/apps/web/src/pages/admin/AddEmployee.tsx
@@ -9,10 +9,6 @@ type FormState = {
   address: string;
   phone: string;
   reportingPerson: string;
-  casualLeaves: string;
-  paidLeaves: string;
-  unpaidLeaves: string;
-  sickLeaves: string;
 };
 
 export default function AddEmployee() {
@@ -24,10 +20,6 @@ export default function AddEmployee() {
     address: "",
     phone: "",
     reportingPerson: "",
-    casualLeaves: "0",
-    paidLeaves: "0",
-    unpaidLeaves: "0",
-    sickLeaves: "0",
   });
   const [docs, setDocs] = useState<FileList | null>(null);
   const [submitting, setSubmitting] = useState(false);
@@ -82,10 +74,6 @@ export default function AddEmployee() {
         address: "",
         phone: "",
         reportingPerson: "",
-        casualLeaves: "0",
-        paidLeaves: "0",
-        unpaidLeaves: "0",
-        sickLeaves: "0",
       });
       setDocs(null);
       setOk("Employee added");
@@ -208,40 +196,6 @@ export default function AddEmployee() {
             </Field>
           </div>
 
-          <div className="grid gap-4 md:grid-cols-4">
-            <Field label="Casual Leaves">
-              <input
-                type="number"
-                className="w-full rounded-md border border-border bg-surface px-3 py-2 outline-none focus:ring-2 focus:ring-primary"
-                value={form.casualLeaves}
-                onChange={(e) => onChange("casualLeaves", e.target.value)}
-              />
-            </Field>
-            <Field label="Paid Leaves">
-              <input
-                type="number"
-                className="w-full rounded-md border border-border bg-surface px-3 py-2 outline-none focus:ring-2 focus:ring-primary"
-                value={form.paidLeaves}
-                onChange={(e) => onChange("paidLeaves", e.target.value)}
-              />
-            </Field>
-            <Field label="Unpaid Leaves">
-              <input
-                type="number"
-                className="w-full rounded-md border border-border bg-surface px-3 py-2 outline-none focus:ring-2 focus:ring-primary"
-                value={form.unpaidLeaves}
-                onChange={(e) => onChange("unpaidLeaves", e.target.value)}
-              />
-            </Field>
-            <Field label="Sick Leaves">
-              <input
-                type="number"
-                className="w-full rounded-md border border-border bg-surface px-3 py-2 outline-none focus:ring-2 focus:ring-primary"
-                value={form.sickLeaves}
-                onChange={(e) => onChange("sickLeaves", e.target.value)}
-              />
-            </Field>
-          </div>
 
           <div className="grid gap-4 md:grid-cols-2">
             <Field label="Documents">

--- a/apps/web/src/pages/admin/LeaveSettings.tsx
+++ b/apps/web/src/pages/admin/LeaveSettings.tsx
@@ -1,0 +1,138 @@
+import { useState, useEffect, FormEvent } from "react";
+import { api } from "../../lib/api";
+
+type FormState = {
+  casual: string;
+  paid: string;
+  sick: string;
+};
+
+export default function LeaveSettings() {
+  const [form, setForm] = useState<FormState>({
+    casual: "0",
+    paid: "0",
+    sick: "0",
+  });
+  const [submitting, setSubmitting] = useState(false);
+  const [ok, setOk] = useState<string | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await api.get("/companies/leave-policy");
+        const p = res.data.leavePolicy || {};
+        setForm({
+          casual: String(p.casual ?? 0),
+          paid: String(p.paid ?? 0),
+          sick: String(p.sick ?? 0),
+        });
+      } catch {
+        // ignore
+      }
+    })();
+  }, []);
+
+  function onChange<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  }
+
+  async function submit(e: FormEvent) {
+    e.preventDefault();
+    setOk(null);
+    setErr(null);
+    try {
+      setSubmitting(true);
+      await api.put("/companies/leave-policy", {
+        casual: parseInt(form.casual, 10) || 0,
+        paid: parseInt(form.paid, 10) || 0,
+        sick: parseInt(form.sick, 10) || 0,
+      });
+      setOk("Leave policy updated");
+    } catch (e: any) {
+      setErr(e?.response?.data?.error || "Failed to update leave policy");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h2 className="text-3xl font-bold">Leave Settings</h2>
+        <p className="text-sm text-muted">Manage default leave allocation.</p>
+      </div>
+
+      {err && (
+        <div className="rounded-md border border-error/20 bg-red-50 px-4 py-2 text-sm text-error">
+          {err}
+        </div>
+      )}
+      {ok && (
+        <div className="rounded-md border border-success/20 bg-green-50 px-4 py-2 text-sm text-success">
+          {ok}
+        </div>
+      )}
+
+      <section className="rounded-lg border border-border bg-surface shadow-sm">
+        <div className="border-b border-border px-6 py-4">
+          <h3 className="text-lg font-semibold">Leave Policy</h3>
+        </div>
+
+        <form onSubmit={submit} className="px-6 py-5 space-y-5">
+          <div className="grid gap-4 md:grid-cols-3">
+            <Field label="Casual Leaves">
+              <input
+                type="number"
+                className="w-full rounded-md border border-border bg-surface px-3 py-2 outline-none focus:ring-2 focus:ring-primary"
+                value={form.casual}
+                onChange={(e) => onChange("casual", e.target.value)}
+              />
+            </Field>
+            <Field label="Paid Leaves">
+              <input
+                type="number"
+                className="w-full rounded-md border border-border bg-surface px-3 py-2 outline-none focus:ring-2 focus:ring-primary"
+                value={form.paid}
+                onChange={(e) => onChange("paid", e.target.value)}
+              />
+            </Field>
+            <Field label="Sick Leaves">
+              <input
+                type="number"
+                className="w-full rounded-md border border-border bg-surface px-3 py-2 outline-none focus:ring-2 focus:ring-primary"
+                value={form.sick}
+                onChange={(e) => onChange("sick", e.target.value)}
+              />
+            </Field>
+          </div>
+          <div className="pt-2">
+            <button
+              type="submit"
+              disabled={submitting}
+              className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-white disabled:opacity-60"
+            >
+              {submitting ? "Saving..." : "Save"}
+            </button>
+          </div>
+        </form>
+      </section>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-2">
+      <label className="text-sm font-medium">{label}</label>
+      {children}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- store default leave policy on company
- allow admins to update leave policy via new page
- remove per-employee leave inputs and use policy defaults when creating employees

## Testing
- `npm test`
- `npm run build -w apps/web`
- `node --check apps/api/src/routes/companies.js`
- `node --check apps/api/src/models/Company.js`


------
https://chatgpt.com/codex/tasks/task_e_68ad3ed8caac832b8ddb02b1ecb5f552