### PR TITLE
Add bank holiday management and monthly work reports

### DIFF
--- a/apps/api/src/models/Company.js
+++ b/apps/api/src/models/Company.js
@@ -8,7 +8,13 @@ const CompanySchema = new mongoose.Schema(
       casual: { type: Number, default: 0 },
       paid: { type: Number, default: 0 },
       sick: { type: Number, default: 0 }
-    }
+    },
+    bankHolidays: [
+      {
+        date: { type: Date, required: true },
+        name: { type: String }
+      }
+    ]
   },
   { timestamps: true }
 );

--- a/apps/web/src/pages/admin/EmployeeDetails.tsx
+++ b/apps/web/src/pages/admin/EmployeeDetails.tsx
@@ -14,6 +14,14 @@ export default function EmployeeDetails() {
   const [employee, setEmployee] = useState<Employee | null>(null);
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);
+  const [month, setMonth] = useState(
+    new Date().toISOString().slice(0, 7)
+  );
+  const [report, setReport] = useState<{ workedDays: number; leaveDays: number } | null>(
+    null
+  );
+  const [rLoading, setRLoading] = useState(false);
+  const [rErr, setRErr] = useState<string | null>(null);
 
   useEffect(() => {
     async function load() {
@@ -29,6 +37,24 @@ export default function EmployeeDetails() {
     }
     load();
   }, [id]);
+
+  useEffect(() => {
+    async function loadReport() {
+      if (!id) return;
+      try {
+        setRLoading(true);
+        const res = await api.get(`/attendance/report/${id}`, {
+          params: { month },
+        });
+        setReport(res.data.report);
+      } catch (e: any) {
+        setRErr(e?.response?.data?.error || "Failed to load report");
+      } finally {
+        setRLoading(false);
+      }
+    }
+    loadReport();
+  }, [id, month]);
 
   const base = import.meta.env.VITE_API_URL || "http://localhost:4000";
 
@@ -60,6 +86,26 @@ export default function EmployeeDetails() {
               </li>
             ))}
           </ul>
+        )}
+      </section>
+      <section className="space-y-4">
+        <h3 className="font-semibold">Monthly Report</h3>
+        {rErr && (
+          <div className="text-sm text-error">{rErr}</div>
+        )}
+        <div className="flex items-center gap-4">
+          <input
+            type="month"
+            value={month}
+            onChange={(e) => setMonth(e.target.value)}
+            className="rounded-md border border-border bg-surface px-3 py-2 outline-none focus:ring-2 focus:ring-primary"
+          />
+          {rLoading && <div className="text-sm text-muted">Loading…</div>}
+        </div>
+        {report && !rLoading && (
+          <div className="text-sm">
+            Worked Days: {report.workedDays}, Leave Days: {report.leaveDays}
+          </div>
         )}
       </section>
     </div>

--- a/apps/web/src/pages/employee/AttendanceRecords.tsx
+++ b/apps/web/src/pages/employee/AttendanceRecords.tsx
@@ -43,6 +43,10 @@ export default function AttendanceRecords() {
   const [q, setQ] = useState(""); // free text filter (date string)
   const [from, setFrom] = useState<string>(""); // yyyy-mm-dd
   const [to, setTo] = useState<string>(""); // yyyy-mm-dd
+  const [month, setMonth] = useState(new Date().toISOString().slice(0, 7));
+  const [summary, setSummary] = useState<{ workedDays: number; leaveDays: number } | null>(
+    null
+  );
 
   async function load() {
     try {
@@ -60,6 +64,17 @@ export default function AttendanceRecords() {
   useEffect(() => {
     load();
   }, []);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await api.get("/attendance/report", { params: { month } });
+        setSummary(res.data.report);
+      } catch {
+        // ignore
+      }
+    })();
+  }, [month]);
 
   const filtered = useMemo(() => {
     const term = q.trim().toLowerCase();
@@ -123,6 +138,22 @@ export default function AttendanceRecords() {
 
   return (
     <div className="space-y-8">
+      <section className="space-y-2">
+        <h3 className="text-xl font-semibold">Monthly Report</h3>
+        <div className="flex items-center gap-4">
+          <input
+            type="month"
+            value={month}
+            onChange={(e) => setMonth(e.target.value)}
+            className="rounded-md border border-border bg-surface px-3 py-2 outline-none focus:ring-2 focus:ring-primary"
+          />
+          {summary && (
+            <div className="text-sm">
+              Worked Days: {summary.workedDays}, Leave Days: {summary.leaveDays}
+            </div>
+          )}
+        </div>
+      </section>
       <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
         <div>
           <h2 className="text-3xl font-bold">Attendance Records</h2>


### PR DESCRIPTION
## Summary
- allow admins to record company bank holidays
- skip bank holidays when approving leave and in monthly work reports
- provide monthly work summaries for employees and admins

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build -w apps/web`

------
https://chatgpt.com/codex/tasks/task_e_68ad45fef050832baf72b462c4bf7391