### PR TITLE
feat: allow HR and managers to view company attendance

### DIFF
--- a/apps/web/src/pages/employee/AttendanceRecords.tsx
+++ b/apps/web/src/pages/employee/AttendanceRecords.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { api } from "../../lib/api";
+import { getEmployee } from "../../lib/auth";
+import AdminAttendanceList from "../admin/AttendanceList";
 
 type AttRecord = {
   date: string; // ISO date (startOfDay)
@@ -36,6 +38,15 @@ function inferWorkedMs(r: AttRecord) {
 }
 
 export default function AttendanceRecords() {
+  const u = getEmployee();
+  const canViewCompany =
+    ["ADMIN", "SUPERADMIN"].includes(u?.primaryRole || "") ||
+    (u?.subRoles || []).some((r) => r === "hr" || r === "manager");
+
+  if (canViewCompany) {
+    return <AdminAttendanceList />;
+  }
+
   const [rows, setRows] = useState<AttRecord[]>([]);
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);


### PR DESCRIPTION
## Summary
- allow HR and manager sub-roles to access company attendance reports
- show company-wide attendance UI to HR, managers, and admins

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build -w apps/web`


------
https://chatgpt.com/codex/tasks/task_e_68ad49286d58832b8c37d7a450a66017