### PR TITLE
Add employee-wise attendance summary for HR managers

### DIFF
--- a/apps/api/src/routes/attendance.js
+++ b/apps/api/src/routes/attendance.js
@@ -164,4 +164,69 @@ router.get('/company/history', auth, async (req, res) => {
   res.json({ attendance });
 });
 
+router.get('/company/report', auth, async (req, res) => {
+  const allowed =
+    ['ADMIN', 'SUPERADMIN'].includes(req.employee.primaryRole) ||
+    (req.employee.subRoles || []).some((r) => ['hr', 'manager'].includes(r));
+  if (!allowed) return res.status(403).json({ error: 'Forbidden' });
+
+  const { month } = req.query;
+  let start;
+  if (month) {
+    start = startOfDay(new Date(month + '-01'));
+  } else {
+    const now = new Date();
+    start = startOfDay(new Date(now.getFullYear(), now.getMonth(), 1));
+  }
+  const end = new Date(start);
+  end.setMonth(end.getMonth() + 1);
+
+  const employees = await Employee.find({
+    company: req.employee.company,
+    primaryRole: 'EMPLOYEE'
+  }).select('_id name');
+
+  const counts = await Attendance.aggregate([
+    {
+      $match: {
+        employee: { $in: employees.map((u) => u._id) },
+        date: { $gte: start, $lt: end }
+      }
+    },
+    { $group: { _id: '$employee', workedDays: { $sum: 1 } } }
+  ]);
+  const countMap = new Map(counts.map((c) => [String(c._id), c.workedDays]));
+
+  const company = await Company.findById(req.employee.company).select('bankHolidays');
+
+  const report = [];
+  for (const emp of employees) {
+    const leaves = await Leave.find({
+      employee: emp._id,
+      status: 'APPROVED',
+      startDate: { $lte: end },
+      endDate: { $gte: start }
+    });
+
+    let leaveDays = 0;
+    for (const l of leaves) {
+      const s = l.startDate < start ? start : new Date(l.startDate);
+      const e = l.endDate > end ? end : new Date(l.endDate);
+      const total = Math.round((e - s) / 86400000) + 1;
+      const holidays = (company?.bankHolidays || []).filter(
+        (h) => h.date >= s && h.date <= e
+      ).length;
+      leaveDays += Math.max(total - holidays, 0);
+    }
+
+    report.push({
+      employee: { id: emp._id, name: emp.name },
+      workedDays: countMap.get(String(emp._id)) || 0,
+      leaveDays
+    });
+  }
+
+  res.json({ report });
+});
+
 module.exports = router;


### PR DESCRIPTION
## Summary
- expose `/attendance/company/report` API for admins and HR managers to get monthly worked/leave days per employee
- add Summary view in admin attendance page to show employee-wise stats

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build -w apps/web`

------
https://chatgpt.com/codex/tasks/task_e_68ad4f38ad14832ba9e9d49223e5e1ea