### PR TITLE
Allow HR and managers to view company attendance

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -74,6 +74,14 @@ export default function App() {
       >
         <Route index element={<EmployeeDash />} />
         <Route path="attendance" element={<AttendanceRecords />} />
+        <Route
+          path="attendances"
+          element={
+            <RoleGuard sub={["hr", "manager"]}>
+              <AttendanceList />
+            </RoleGuard>
+          }
+        />
         <Route path="leave" element={<LeaveRequest />} />
         <Route path="approvals" element={<LeaveApprovals />} />
         <Route path="documents" element={<Documents />} />

--- a/apps/web/src/layouts/EmployeeLayout.tsx
+++ b/apps/web/src/layouts/EmployeeLayout.tsx
@@ -11,6 +11,7 @@ import {
   User,
   FileText,
   ClipboardList,
+  Users,
 } from "lucide-react";
 
 export default function EmployeeLayout() {
@@ -30,8 +31,17 @@ export default function EmployeeLayout() {
     { to: "/app/documents", label: "Documents", icon: FileText },
   ];
 
+  if (u?.subRoles?.some((r) => ["hr", "manager"].includes(r))) {
+    links.splice(2, 0, {
+      to: "/app/attendances",
+      label: "Attendances",
+      icon: Users,
+    });
+  }
+
   const title = useMemo(() => {
     if (pathname === "/app") return "Dashboard";
+    if (pathname.startsWith("/app/attendances")) return "Attendances";
     if (pathname.startsWith("/app/attendance")) return "Attendance";
     if (pathname.startsWith("/app/leave")) return "Leave";
     if (pathname.startsWith("/app/approvals")) return "Leave Approvals";


### PR DESCRIPTION
## Summary
- Show Attendances link for HR and manager roles within employee layout
- Add route for HR and managers to access full company attendance list

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ad521b3a5c832b9ceecbcfef6660d5