### PR TITLE
feat: show remaining leave balance

### DIFF
--- a/apps/api/src/routes/auth.js
+++ b/apps/api/src/routes/auth.js
@@ -16,7 +16,8 @@ router.post('/login', async (req, res) => {
     email: employee.email,
     primaryRole: employee.primaryRole,
     subRoles: employee.subRoles,
-    company: employee.company
+    company: employee.company,
+    leaveBalances: employee.leaveBalances,
   };
   const token = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '2h' });
   res.json({ token, employee: payload });
@@ -31,7 +32,8 @@ router.get('/me', auth, async (req, res) => {
     email: employee.email,
     primaryRole: employee.primaryRole,
     subRoles: employee.subRoles,
-    company: employee.company
+    company: employee.company,
+    leaveBalances: employee.leaveBalances,
   };
   res.json({ employee: payload });
 });

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,6 +1,13 @@
 export type PrimaryRole = 'SUPERADMIN' | 'ADMIN' | 'EMPLOYEE';
 export type SubRole = 'hr' | 'manager' | 'developer' | 'plain';
 
+export type LeaveBalances = {
+  casual: number;
+  paid: number;
+  unpaid: number;
+  sick: number;
+};
+
 export type Employee = {
   id: string;
   name: string;
@@ -8,6 +15,7 @@ export type Employee = {
   primaryRole: PrimaryRole;
   subRoles: SubRole[];
   company?: string;
+  leaveBalances: LeaveBalances;
 };
 
 export function setAuth(token: string, employee: Employee) {


### PR DESCRIPTION
## Summary
- include leave balances in auth responses
- persist leave balance data on the client
- display current leave balances on the leave request page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build -w apps/web`


------
https://chatgpt.com/codex/tasks/task_e_68ad534fd1b8832b8299be5801db1ba0