### PR TITLE
feat: allow admin to update employee reporting person

### DIFF
--- a/apps/api/src/routes/documents.js
+++ b/apps/api/src/routes/documents.js
@@ -31,10 +31,21 @@ router.get(
   requirePrimary(["ADMIN", "SUPERADMIN"]),
   async (req, res) => {
     const emp = await Employee.findById(req.params.id)
-      .select("name email documents")
+      .select("name email documents reportingPerson")
+      .populate("reportingPerson", "name")
       .lean();
     if (!emp) return res.status(404).json({ error: "Not found" });
-    res.json({ employee: { id: emp._id, name: emp.name, email: emp.email, documents: emp.documents } });
+    res.json({
+      employee: {
+        id: emp._id,
+        name: emp.name,
+        email: emp.email,
+        documents: emp.documents,
+        reportingPerson: emp.reportingPerson
+          ? { id: emp.reportingPerson._id, name: emp.reportingPerson.name }
+          : null,
+      },
+    });
   }
 );
 

--- a/apps/web/src/pages/admin/EmployeeDetails.tsx
+++ b/apps/web/src/pages/admin/EmployeeDetails.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, FormEvent } from "react";
 import { useParams } from "react-router-dom";
 import { api } from "../../lib/api";
 
@@ -7,6 +7,7 @@ type Employee = {
   name: string;
   email: string;
   documents: string[];
+  reportingPerson?: { id: string; name: string } | null;
 };
 
 export default function EmployeeDetails() {
@@ -22,6 +23,11 @@ export default function EmployeeDetails() {
   );
   const [rLoading, setRLoading] = useState(false);
   const [rErr, setRErr] = useState<string | null>(null);
+  const [employees, setEmployees] = useState<{ id: string; name: string }[]>([]);
+  const [reportingPerson, setReportingPerson] = useState("");
+  const [uLoading, setULoading] = useState(false);
+  const [uErr, setUErr] = useState<string | null>(null);
+  const [uOk, setUOk] = useState<string | null>(null);
 
   useEffect(() => {
     async function load() {
@@ -29,6 +35,7 @@ export default function EmployeeDetails() {
         setLoading(true);
         const res = await api.get(`/documents/${id}`);
         setEmployee(res.data.employee);
+        setReportingPerson(res.data.employee.reportingPerson?.id || "");
       } catch (e: any) {
         setErr(e?.response?.data?.error || "Failed to load employee");
       } finally {
@@ -37,6 +44,17 @@ export default function EmployeeDetails() {
     }
     load();
   }, [id]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await api.get("/companies/employees");
+        setEmployees(res.data.employees || []);
+      } catch {
+        // ignore
+      }
+    })();
+  }, []);
 
   useEffect(() => {
     async function loadReport() {
@@ -56,6 +74,24 @@ export default function EmployeeDetails() {
     loadReport();
   }, [id, month]);
 
+  async function updateReporting(e: FormEvent) {
+    e.preventDefault();
+    if (!id) return;
+    try {
+      setULoading(true);
+      setUErr(null);
+      setUOk(null);
+      await api.put(`/companies/employees/${id}/reporting`, {
+        reportingPerson,
+      });
+      setUOk("Reporting person updated");
+    } catch (e: any) {
+      setUErr(e?.response?.data?.error || "Failed to update");
+    } finally {
+      setULoading(false);
+    }
+  }
+
   const base = import.meta.env.VITE_API_URL || "http://localhost:4000";
 
   if (loading) return <div>Loading…</div>;
@@ -68,6 +104,38 @@ export default function EmployeeDetails() {
         <h2 className="text-3xl font-bold">{employee.name}</h2>
         <p className="text-sm text-muted">{employee.email}</p>
       </div>
+      <section className="space-y-2">
+        <h3 className="font-semibold">Reporting Person</h3>
+        {uErr && (
+          <div className="text-sm text-error">{uErr}</div>
+        )}
+        {uOk && (
+          <div className="text-sm text-success">{uOk}</div>
+        )}
+        <form onSubmit={updateReporting} className="flex items-center gap-2">
+          <select
+            value={reportingPerson}
+            onChange={(e) => setReportingPerson(e.target.value)}
+            className="rounded-md border border-border bg-surface px-3 py-2 outline-none focus:ring-2 focus:ring-primary"
+          >
+            <option value="">None</option>
+            {employees
+              .filter((e) => e.id !== id)
+              .map((e) => (
+                <option key={e.id} value={e.id}>
+                  {e.name}
+                </option>
+              ))}
+          </select>
+          <button
+            type="submit"
+            disabled={uLoading}
+            className="rounded-md bg-primary px-4 py-2 text-white disabled:opacity-50"
+          >
+            {uLoading ? "Saving…" : "Save"}
+          </button>
+        </form>
+      </section>
       <section>
         <h3 className="font-semibold mb-2">Documents</h3>
         {employee.documents?.length === 0 ? (


### PR DESCRIPTION
## Summary
- add API endpoint for admins to set or change an employee's reporting person
- expose current reporting person when viewing an employee's documents
- let admins update reporting person from employee details screen

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build -w apps/web`


------
https://chatgpt.com/codex/tasks/task_e_68ad57d6d79c832ba49ad4b750f8bdd1