### PR TITLE
Auto punch out at midnight

### DIFF
--- a/apps/api/src/index.js
+++ b/apps/api/src/index.js
@@ -3,6 +3,7 @@ const cors = require('cors');
 const cookieParser = require('cookie-parser');
 const path = require('path');
 const { connectDB } = require('./config');
+const { scheduleAutoPunchOut } = require('./jobs/autoPunchOut');
 
 const app = express();
 app.use(express.json());
@@ -19,6 +20,7 @@ app.use('/leaves', require('./routes/leaves'));
 app.use('/documents', require('./routes/documents'));
 
 connectDB().then(() => {
+  scheduleAutoPunchOut();
   const port = process.env.PORT || 4000;
   app.listen(port, () => console.log('API on ' + port));
 });

--- a/apps/api/src/jobs/autoPunchOut.js
+++ b/apps/api/src/jobs/autoPunchOut.js
@@ -1,0 +1,33 @@
+const Attendance = require('../models/Attendance');
+
+function scheduleAutoPunchOut() {
+  // check every minute for midnight and auto punch out any pending records
+  setInterval(async () => {
+    try {
+      const now = new Date();
+      if (now.getMinutes() !== 0 || now.getHours() !== 0) return;
+      const midnight = new Date(now);
+      midnight.setSeconds(0, 0);
+      // get yesterday's date
+      const y = new Date(midnight);
+      y.setDate(y.getDate() - 1);
+      y.setHours(0, 0, 0, 0);
+      const records = await Attendance.find({
+        date: y,
+        lastPunchIn: { $ne: null },
+        lastPunchOut: { $exists: false }
+      });
+      for (const r of records) {
+        r.workedMs += midnight.getTime() - r.lastPunchIn.getTime();
+        r.lastPunchOut = midnight;
+        r.lastPunchIn = undefined;
+        r.autoPunchOut = true;
+        await r.save();
+      }
+    } catch (err) {
+      console.error('autoPunchOut job error', err);
+    }
+  }, 60 * 1000);
+}
+
+module.exports = { scheduleAutoPunchOut };

--- a/apps/api/src/models/Attendance.js
+++ b/apps/api/src/models/Attendance.js
@@ -6,7 +6,8 @@ const AttendanceSchema = new mongoose.Schema({
   firstPunchIn: { type: Date },
   lastPunchOut: { type: Date },
   lastPunchIn: { type: Date },
-  workedMs: { type: Number, default: 0 }
+  workedMs: { type: Number, default: 0 },
+  autoPunchOut: { type: Boolean, default: false }
 });
 
 AttendanceSchema.index({ employee: 1, date: 1 }, { unique: true });

--- a/apps/web/src/pages/employee/AttendanceRecords.tsx
+++ b/apps/web/src/pages/employee/AttendanceRecords.tsx
@@ -7,6 +7,7 @@ type AttRecord = {
   firstPunchIn?: string;
   lastPunchOut?: string;
   workedMs?: number;
+  autoPunchOut?: boolean;
 };
 
 function fmtDate(d: string | Date) {
@@ -359,6 +360,9 @@ export default function AttendanceRecords() {
                             </div>
                           </div>
                         )}
+                        {rec?.autoPunchOut && (
+                          <div className="absolute bottom-1 left-1 text-[10px] text-error">!</div>
+                        )}
                       </button>
                     );
                   })}
@@ -394,6 +398,9 @@ export default function AttendanceRecords() {
               <div>{fmtTime(detail.lastPunchOut)}</div>
               <div className="text-muted">Worked</div>
               <div>{fmtDur(inferWorkedMs(detail))}</div>
+              {detail.autoPunchOut && (
+                <div className="col-span-2 mt-2 text-xs text-error">Auto punched out</div>
+              )}
             </div>
             <div className="mt-4 flex justify-end">
               <button


### PR DESCRIPTION
## Summary
- add auto-punch-out job to close open attendance records at midnight
- track auto punches in attendance records
- mark auto punch-outs on attendance calendar

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68ad747d63c0832b8cac96aab902df20