### PR TITLE
feat: allow assigning roles to employees

### DIFF
--- a/apps/api/src/routes/documents.js
+++ b/apps/api/src/routes/documents.js
@@ -31,7 +31,7 @@ router.get(
   requirePrimary(["ADMIN", "SUPERADMIN"]),
   async (req, res) => {
     const emp = await Employee.findById(req.params.id)
-      .select("name email dob documents reportingPerson")
+      .select("name email dob documents reportingPerson subRoles")
       .populate("reportingPerson", "name")
       .lean();
     if (!emp) return res.status(404).json({ error: "Not found" });
@@ -45,6 +45,7 @@ router.get(
         reportingPerson: emp.reportingPerson
           ? { id: emp.reportingPerson._id, name: emp.reportingPerson.name }
           : null,
+        subRoles: emp.subRoles || [],
       },
     });
   }


### PR DESCRIPTION
## Summary
- allow admins to update an employee's role
- expose sub roles in employee details endpoint
- let admins set HR/Manager/Developer roles from Employee Details page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build -w apps/web`

------
https://chatgpt.com/codex/tasks/task_e_68ad8089fa20832bae959f7c1d7bd92d