### PR TITLE
Add profile management and employee ID

### DIFF
--- a/apps/api/src/models/Employee.js
+++ b/apps/api/src/models/Employee.js
@@ -11,6 +11,14 @@ const EmployeeSchema = new mongoose.Schema(
     address: { type: String },
     phone: { type: String },
     dob: { type: Date },
+    employeeId: { type: String, unique: true, index: true },
+    aadharNumber: { type: String },
+    panNumber: { type: String },
+    bankDetails: {
+      accountNumber: { type: String },
+      bankName: { type: String },
+      ifsc: { type: String }
+    },
     documents: { type: [String], default: [] },
     reportingPerson: { type: mongoose.Schema.Types.ObjectId, ref: 'Employee' },
     leaveBalances: {

--- a/apps/api/src/routes/auth.js
+++ b/apps/api/src/routes/auth.js
@@ -20,6 +20,10 @@ router.post('/login', async (req, res) => {
     subRoles: employee.subRoles,
     company: employee.company,
     leaveBalances: employee.leaveBalances,
+    employeeId: employee.employeeId,
+    aadharNumber: employee.aadharNumber,
+    panNumber: employee.panNumber,
+    bankDetails: employee.bankDetails,
   };
   const token = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '2h' });
   res.json({ token, employee: payload });
@@ -37,8 +41,27 @@ router.get('/me', auth, async (req, res) => {
     subRoles: employee.subRoles,
     company: employee.company,
     leaveBalances: employee.leaveBalances,
+    employeeId: employee.employeeId,
+    aadharNumber: employee.aadharNumber,
+    panNumber: employee.panNumber,
+    bankDetails: employee.bankDetails,
   };
   res.json({ employee: payload });
+});
+
+router.put('/me', auth, async (req, res) => {
+  const { aadharNumber, panNumber, bankName, bankAccountNumber, bankIfsc } = req.body;
+  const employee = await Employee.findById(req.employee.id);
+  if (!employee) return res.status(404).json({ error: 'Not found' });
+  if (aadharNumber !== undefined) employee.aadharNumber = aadharNumber;
+  if (panNumber !== undefined) employee.panNumber = panNumber;
+  employee.bankDetails = {
+    accountNumber: bankAccountNumber || employee.bankDetails?.accountNumber,
+    bankName: bankName || employee.bankDetails?.bankName,
+    ifsc: bankIfsc || employee.bankDetails?.ifsc,
+  };
+  await employee.save();
+  res.json({ message: 'Profile updated' });
 });
 
 module.exports = router;

--- a/apps/api/src/routes/companies.js
+++ b/apps/api/src/routes/companies.js
@@ -140,14 +140,15 @@ router.post("/employees", auth, upload.array("documents"), async (req, res) => {
     phone,
     dob,
     reportingPerson,
+    employeeId,
   } = req.body;
-  if (!name || !email || !password || !role)
+  if (!name || !email || !password || !role || !employeeId)
     return res.status(400).json({ error: "Missing fields" });
   const company = await Company.findOne({ admin: req.employee.id });
   if (!company) return res.status(400).json({ error: "Company not found" });
   if (!company.roles.includes(role))
     return res.status(400).json({ error: "Invalid role" });
-  let existing = await Employee.findOne({ email });
+  let existing = await Employee.findOne({ $or: [{ email }, { employeeId }] });
   if (existing)
     return res.status(400).json({ error: "Employee already exists" });
   const passwordHash = await bcrypt.hash(password, 10);
@@ -174,6 +175,7 @@ router.post("/employees", auth, upload.array("documents"), async (req, res) => {
     address,
     phone,
     dob: dob ? new Date(dob) : undefined,
+    employeeId,
     documents,
     reportingPerson: reporting ? reporting._id : undefined,
     leaveBalances,

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
 import Login from './pages/Login';
+import Profile from './pages/Profile';
 import Protected from './components/Protected';
 import RoleGuard from './components/RoleGuard';
 import SuperAdminLayout from './layouts/SuperAdminLayout';
@@ -41,6 +42,7 @@ export default function App() {
         <Route index element={<SADash />} />
         <Route path="companies" element={<CompanyList />} />
         <Route path="companies/add" element={<AddCompany />} />
+        <Route path="profile" element={<Profile />} />
       </Route>
 
       <Route
@@ -61,6 +63,7 @@ export default function App() {
         <Route path="leave-settings" element={<LeaveSettings />} />
         <Route path="roles" element={<RoleSettings />} />
         <Route path="leaves" element={<LeaveRequests />} />
+        <Route path="profile" element={<Profile />} />
       </Route>
 
       <Route
@@ -86,6 +89,7 @@ export default function App() {
         <Route path="leave" element={<LeaveRequest />} />
         <Route path="approvals" element={<LeaveApprovals />} />
         <Route path="documents" element={<Documents />} />
+        <Route path="profile" element={<Profile />} />
       </Route>
 
       <Route path="*" element={<Navigate to="/login" replace />} />

--- a/apps/web/src/layouts/AdminLayout.tsx
+++ b/apps/web/src/layouts/AdminLayout.tsx
@@ -32,6 +32,7 @@ export default function AdminLayout() {
     { to: "/admin/attendances", label: "Attendances", icon: CalendarCheck2 },
     { to: "/admin/leave-settings", label: "Leave Settings", icon: Settings },
     { to: "/admin/leaves", label: "Leave Requests", icon: ClipboardList },
+    { to: "/admin/profile", label: "Profile", icon: User },
   ];
 
   const title = useMemo(() => {
@@ -43,6 +44,7 @@ export default function AdminLayout() {
     if (pathname.startsWith("/admin/attendances")) return "Attendances";
     if (pathname.startsWith("/admin/leave-settings")) return "Leave Settings";
     if (pathname.startsWith("/admin/leaves")) return "Leave Requests";
+    if (pathname.startsWith("/admin/profile")) return "Profile";
     return "Admin";
   }, [pathname]);
 

--- a/apps/web/src/layouts/EmployeeLayout.tsx
+++ b/apps/web/src/layouts/EmployeeLayout.tsx
@@ -32,6 +32,7 @@ export default function EmployeeLayout() {
     { to: "/app/leave", label: "Leave", icon: CalendarCheck2 },
     { to: "/app/approvals", label: "Approvals", icon: ClipboardList },
     { to: "/app/documents", label: "Documents", icon: FileText },
+    { to: "/app/profile", label: "Profile", icon: User },
   ];
 
   // if HR or Manager → add "Attendances"
@@ -50,6 +51,7 @@ export default function EmployeeLayout() {
     if (pathname.startsWith("/app/leave")) return "Leave";
     if (pathname.startsWith("/app/approvals")) return "Leave Approvals";
     if (pathname.startsWith("/app/documents")) return "Documents";
+    if (pathname.startsWith("/app/profile")) return "Profile";
     return "Employee";
   }, [pathname]);
 

--- a/apps/web/src/layouts/SuperAdminLayout.tsx
+++ b/apps/web/src/layouts/SuperAdminLayout.tsx
@@ -25,12 +25,14 @@ export default function SuperAdminLayout() {
     { to: "/superadmin", label: "Dashboard", icon: LayoutDashboard },
     { to: "/superadmin/companies", label: "Companies", icon: Building2 },
     { to: "/superadmin/companies/add", label: "Add Company", icon: PlusCircle },
+    { to: "/superadmin/profile", label: "Profile", icon: User },
   ];
 
   const title = useMemo(() => {
     if (pathname === "/superadmin") return "Dashboard";
     if (pathname.startsWith("/superadmin/companies/add")) return "Add Company";
     if (pathname.startsWith("/superadmin/companies")) return "Companies";
+    if (pathname.startsWith("/superadmin/profile")) return "Profile";
     return "Superadmin";
   }, [pathname]);
 

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -8,6 +8,12 @@ export type LeaveBalances = {
   sick: number;
 };
 
+export type BankDetails = {
+  accountNumber?: string;
+  bankName?: string;
+  ifsc?: string;
+};
+
 export type Employee = {
   id: string;
   name: string;
@@ -16,6 +22,10 @@ export type Employee = {
   subRoles: SubRole[];
   company?: string;
   leaveBalances: LeaveBalances;
+  employeeId?: string;
+  aadharNumber?: string;
+  panNumber?: string;
+  bankDetails?: BankDetails;
 };
 
 export function setAuth(token: string, employee: Employee) {

--- a/apps/web/src/pages/Profile.tsx
+++ b/apps/web/src/pages/Profile.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useState, FormEvent } from "react";
+import { api } from "../lib/api";
+
+interface FormState {
+  aadharNumber: string;
+  panNumber: string;
+  bankName: string;
+  bankAccountNumber: string;
+  bankIfsc: string;
+}
+
+export default function Profile() {
+  const [form, setForm] = useState<FormState>({
+    aadharNumber: "",
+    panNumber: "",
+    bankName: "",
+    bankAccountNumber: "",
+    bankIfsc: "",
+  });
+  const [ok, setOk] = useState<string | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await api.get("/auth/me");
+        const emp = res.data.employee || {};
+        setForm({
+          aadharNumber: emp.aadharNumber || "",
+          panNumber: emp.panNumber || "",
+          bankName: emp.bankDetails?.bankName || "",
+          bankAccountNumber: emp.bankDetails?.accountNumber || "",
+          bankIfsc: emp.bankDetails?.ifsc || "",
+        });
+      } catch {
+        // ignore
+      }
+    })();
+  }, []);
+
+  function onChange<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  }
+
+  async function submit(e: FormEvent) {
+    e.preventDefault();
+    setOk(null);
+    setErr(null);
+    try {
+      await api.put("/auth/me", {
+        aadharNumber: form.aadharNumber,
+        panNumber: form.panNumber,
+        bankName: form.bankName,
+        bankAccountNumber: form.bankAccountNumber,
+        bankIfsc: form.bankIfsc,
+      });
+      setOk("Profile updated");
+    } catch {
+      setErr("Failed to update profile");
+    }
+  }
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h2 className="text-3xl font-bold">Profile</h2>
+        <p className="text-sm text-muted">Update your details.</p>
+      </div>
+
+      {err && (
+        <div className="rounded-md border border-error/20 bg-red-50 px-4 py-2 text-sm text-error">
+          {err}
+        </div>
+      )}
+      {ok && (
+        <div className="rounded-md border border-success/20 bg-green-50 px-4 py-2 text-sm text-success">
+          {ok}
+        </div>
+      )}
+
+      <section className="rounded-lg border border-border bg-surface shadow-sm">
+        <div className="border-b border-border px-6 py-4">
+          <h3 className="text-lg font-semibold">Personal Information</h3>
+        </div>
+
+        <form onSubmit={submit} className="px-6 py-5 space-y-5">
+          <div className="grid gap-4 md:grid-cols-2">
+            <Field label="Aadhar Number">
+              <input
+                className="w-full rounded-md border border-border bg-surface px-3 py-2 outline-none focus:ring-2 focus:ring-primary"
+                value={form.aadharNumber}
+                onChange={(e) => onChange("aadharNumber", e.target.value)}
+              />
+            </Field>
+            <Field label="PAN Number">
+              <input
+                className="w-full rounded-md border border-border bg-surface px-3 py-2 outline-none focus:ring-2 focus:ring-primary"
+                value={form.panNumber}
+                onChange={(e) => onChange("panNumber", e.target.value)}
+              />
+            </Field>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-3">
+            <Field label="Bank Name">
+              <input
+                className="w-full rounded-md border border-border bg-surface px-3 py-2 outline-none focus:ring-2 focus:ring-primary"
+                value={form.bankName}
+                onChange={(e) => onChange("bankName", e.target.value)}
+              />
+            </Field>
+            <Field label="Account Number">
+              <input
+                className="w-full rounded-md border border-border bg-surface px-3 py-2 outline-none focus:ring-2 focus:ring-primary"
+                value={form.bankAccountNumber}
+                onChange={(e) => onChange("bankAccountNumber", e.target.value)}
+              />
+            </Field>
+            <Field label="IFSC Code">
+              <input
+                className="w-full rounded-md border border-border bg-surface px-3 py-2 outline-none focus:ring-2 focus:ring-primary"
+                value={form.bankIfsc}
+                onChange={(e) => onChange("bankIfsc", e.target.value)}
+              />
+            </Field>
+          </div>
+
+          <div className="pt-2">
+            <button
+              type="submit"
+              className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-white"
+            >
+              Save
+            </button>
+          </div>
+        </form>
+      </section>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-2">
+      <label className="text-sm font-medium">{label}</label>
+      {children}
+    </div>
+  );
+}
+

--- a/apps/web/src/pages/admin/AddEmployee.tsx
+++ b/apps/web/src/pages/admin/AddEmployee.tsx
@@ -10,6 +10,7 @@ type FormState = {
   phone: string;
   dob: string;
   reportingPerson: string;
+  employeeId: string;
 };
 
 export default function AddEmployee() {
@@ -22,6 +23,7 @@ export default function AddEmployee() {
     phone: "",
     dob: "",
     reportingPerson: "",
+    employeeId: "",
   });
   const [docs, setDocs] = useState<FileList | null>(null);
   const [submitting, setSubmitting] = useState(false);
@@ -37,7 +39,8 @@ export default function AddEmployee() {
       form.password &&
       form.role &&
       form.address.trim() &&
-      form.phone.trim()
+      form.phone.trim() &&
+      form.employeeId.trim()
     );
   }, [form]);
 
@@ -86,6 +89,7 @@ export default function AddEmployee() {
         phone: "",
         dob: "",
         reportingPerson: "",
+        employeeId: "",
       });
       setDocs(null);
       setOk("Employee added");
@@ -186,6 +190,14 @@ export default function AddEmployee() {
                   </option>
                 ))}
               </select>
+            </Field>
+            <Field label="Employee ID">
+              <input
+                className="w-full rounded-md border border-border bg-surface px-3 py-2 outline-none focus:ring-2 focus:ring-primary"
+                placeholder="EMP001"
+                value={form.employeeId}
+                onChange={(e) => onChange("employeeId", e.target.value)}
+              />
             </Field>
           </div>
 


### PR DESCRIPTION
## Summary
- allow admins to specify employee IDs when creating employees
- add profile data fields (Aadhar, PAN, bank details) to employee model and API
- provide profile page and navigation for all roles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build -w apps/web`

------
https://chatgpt.com/codex/tasks/task_e_68ad8bdd0e68832b90b1cd4987a41c49