### PR TITLE
Add Zod validation and hook-form handling for announcements

### DIFF
--- a/apps/api/src/routes/announcements.js
+++ b/apps/api/src/routes/announcements.js
@@ -65,8 +65,6 @@ router.post("/", auth, async (req, res) => {
 
   const payload = {
     ...validation.data,
-    title: validation.data.title.trim(),
-    message: validation.data.message.trim(),
   };
 
   const ann = await Announcement.create(payload);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,12 +9,15 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.9.1",
     "axios": "^1.7.2",
     "recharts": "^2.10.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hot-toast": "^2.6.0",
-    "react-router-dom": "^6.28.0"
+    "react-hook-form": "^7.53.1",
+    "react-router-dom": "^6.28.0",
+    "zod": "^4.1.11"
   },
   "devDependencies": {
     "@types/react": "^18.2.66",

--- a/apps/web/src/schemas/announcement.ts
+++ b/apps/web/src/schemas/announcement.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+const dateIsValid = (value: string) => {
+  const date = new Date(value);
+  return !Number.isNaN(date.getTime());
+};
+
+export const announcementFormSchema = z.object({
+  title: z
+    .string()
+    .trim()
+    .nonempty("Title is required")
+    .min(3, "Title must be at least 3 characters")
+    .max(120, "Title must be at most 120 characters"),
+  message: z
+    .string()
+    .trim()
+    .nonempty("Message is required")
+    .min(10, "Message must be at least 10 characters")
+    .max(5000, "Message must be at most 5000 characters"),
+  expiresAt: z
+    .union([
+      z.literal(""),
+      z
+        .string()
+        .trim()
+        .refine(dateIsValid, "Enter a valid expiration date"),
+    ])
+    .optional(),
+});
+
+export type AnnouncementFormValues = z.infer<typeof announcementFormSchema>;

--- a/libs/schemas/announcement.js
+++ b/libs/schemas/announcement.js
@@ -1,0 +1,48 @@
+const { z } = require("zod");
+
+const objectIdString = z
+  .string({ required_error: "Identifier is required" })
+  .trim()
+  .min(1, "Identifier is required");
+
+const expiresAtField = z
+  .preprocess(
+    (value) => {
+      if (value === "" || value === null || typeof value === "undefined") {
+        return undefined;
+      }
+      return value;
+    },
+    z.union([
+      z.date(),
+      z
+        .string()
+        .trim()
+        .refine(
+          (value) => !Number.isNaN(new Date(value).getTime()),
+          { message: "Expires at must be a valid date" },
+        )
+        .transform((value) => new Date(value)),
+    ]),
+  )
+  .optional();
+
+const announcementSchema = z.object({
+  company: objectIdString,
+  title: z
+    .string({ required_error: "Title is required" })
+    .trim()
+    .min(3, "Title must be at least 3 characters")
+    .max(120, "Title must be at most 120 characters"),
+  message: z
+    .string({ required_error: "Message is required" })
+    .trim()
+    .min(10, "Message must be at least 10 characters")
+    .max(5000, "Message must be at most 5000 characters"),
+  expiresAt: expiresAtField,
+  createdBy: objectIdString,
+});
+
+module.exports = {
+  announcementSchema,
+};


### PR DESCRIPTION
## Summary
- add a shared Zod schema for announcement payload validation on the API
- wire the admin and employee announcement forms to react-hook-form with Zod-powered client validation and inline errors
- register the new form-validation dependencies in the web workspace package manifest

## Testing
- npm run build -w apps/api
- npm run build -w apps/web *(fails: missing @hookform/resolvers & react-hook-form packages cannot be installed in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d22906cdf8832b84eee0e2cd082ce6