### PR TITLE
Add Zod validation and hook-form handling for announcements

### DIFF
--- a/apps/api/src/routes/announcements.js
+++ b/apps/api/src/routes/announcements.js
@@ -65,8 +65,6 @@ router.post("/", auth, async (req, res) => {
 
   const payload = {
     ...validation.data,
-    title: validation.data.title.trim(),
-    message: validation.data.message.trim(),
   };
 
   const ann = await Announcement.create(payload);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,12 +9,15 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.9.1",
     "axios": "^1.7.2",
     "recharts": "^2.10.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hot-toast": "^2.6.0",
-    "react-router-dom": "^6.28.0"
+    "react-hook-form": "^7.53.1",
+    "react-router-dom": "^6.28.0",
+    "zod": "^4.1.11"
   },
   "devDependencies": {
     "@types/react": "^18.2.66",

--- a/apps/web/src/schemas/announcement.ts
+++ b/apps/web/src/schemas/announcement.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+const dateIsValid = (value: string) => {
+  const date = new Date(value);
+  return !Number.isNaN(date.getTime());
+};
+
+export const announcementFormSchema = z.object({
+  title: z
+    .string()
+    .trim()
+    .nonempty("Title is required")
+    .min(3, "Title must be at least 3 characters")
+    .max(120, "Title must be at most 120 characters"),
+  message: z
+    .string()
+    .trim()
+    .nonempty("Message is required")
+    .min(10, "Message must be at least 10 characters")
+    .max(5000, "Message must be at most 5000 characters"),
+  expiresAt: z
+    .union([
+      z.literal(""),
+      z
+        .string()
+        .trim()
+        .refine(dateIsValid, "Enter a valid expiration date"),
+    ])
+    .optional(),
+});
+
+export type AnnouncementFormValues = z.infer<typeof announcementFormSchema>;

--- a/libs/schemas/announcement.js
+++ b/libs/schemas/announcement.js
@@ -1,0 +1,48 @@
+const { z } = require("zod");
+
+const objectIdString = z
+  .string({ required_error: "Identifier is required" })
+  .trim()
+  .min(1, "Identifier is required");
+
+const expiresAtField = z
+  .preprocess(
+    (value) => {
+      if (value === "" || value === null || typeof value === "undefined") {
+        return undefined;
+      }
+      return value;
+    },
+    z.union([
+      z.date(),
+      z
+        .string()
+        .trim()
+        .refine(
+          (value) => !Number.isNaN(new Date(value).getTime()),
+          { message: "Expires at must be a valid date" },
+        )
+        .transform((value) => new Date(value)),
+    ]),
+  )
+  .optional();
+
+const announcementSchema = z.object({
+  company: objectIdString,
+  title: z
+    .string({ required_error: "Title is required" })
+    .trim()
+    .min(3, "Title must be at least 3 characters")
+    .max(120, "Title must be at most 120 characters"),
+  message: z
+    .string({ required_error: "Message is required" })
+    .trim()
+    .min(10, "Message must be at least 10 characters")
+    .max(5000, "Message must be at most 5000 characters"),
+  expiresAt: expiresAtField,
+  createdBy: objectIdString,
+});
+
+module.exports = {
+  announcementSchema,
+};

--- a/libs/schemas/expense.js
+++ b/libs/schemas/expense.js
@@ -1,0 +1,81 @@
+const { z } = require("zod");
+
+const recurringSchema = z
+  .object({
+    frequency: z.enum(["daily", "weekly", "monthly", "quarterly", "yearly"]),
+    startDate: z.date(),
+    nextDueDate: z.date().nullable().optional(),
+    reminderDaysBefore: z
+      .number({ invalid_type_error: "Reminder days must be a number" })
+      .int("Reminder days must be an integer")
+      .min(0, "Reminder days cannot be negative")
+      .optional()
+      .default(0),
+  })
+  .optional()
+  .nullable();
+
+const voucherSchema = z
+  .object({
+    number: z
+      .string({ required_error: "Voucher number is required" })
+      .trim()
+      .min(1, "Voucher number is required"),
+    authorizedBy: z.string().trim().optional(),
+    sequenceKey: z
+      .string({ required_error: "Voucher sequence key is required" })
+      .trim()
+      .min(1, "Voucher sequence key is required"),
+    pdfFile: z.string().trim().optional(),
+    generatedAt: z.date(),
+  })
+  .optional()
+  .nullable();
+
+const stringField = z
+  .union([z.string(), z.null(), z.undefined()])
+  .transform((val) => (val == null ? "" : String(val)));
+
+const idField = z
+  .union([z.string(), z.null(), z.undefined()])
+  .transform((val) => (val == null ? undefined : String(val).trim()))
+  .refine((val) => val === undefined || val.length > 0, {
+    message: "Id cannot be empty",
+  });
+
+const expenseSchema = z.object({
+  company: z
+    .string({ required_error: "Company is required" })
+    .trim()
+    .min(1, "Company is required"),
+  date: z.date({ required_error: "Date is required" }),
+  category: z
+    .string({ required_error: "Category is required" })
+    .trim()
+    .min(1, "Category is required"),
+  categoryName: z
+    .string({ required_error: "Category name is required" })
+    .trim()
+    .min(1, "Category name is required"),
+  description: stringField,
+  notes: stringField,
+  amount: z
+    .number({ required_error: "Amount is required" })
+    .nonnegative("Amount must be non-negative"),
+  paidBy: z.enum(["cash", "bank", "upi", "card"], {
+    required_error: "Payment mode is required",
+    invalid_type_error: "Payment mode is invalid",
+  }),
+  attachments: z
+    .array(z.string().trim().min(1, "Attachment file name cannot be empty"))
+    .optional()
+    .default([]),
+  isRecurring: z.boolean().optional().default(false),
+  recurring: recurringSchema,
+  hasVoucher: z.boolean().optional().default(false),
+  voucher: voucherSchema,
+  createdBy: idField,
+  updatedBy: idField,
+});
+
+module.exports = { expenseSchema };

--- a/libs/schemas/project.js
+++ b/libs/schemas/project.js
@@ -1,0 +1,40 @@
+const { z } = require("zod");
+
+const projectSchema = z.object({
+  title: z
+    .string({ required_error: "Title is required" })
+    .trim()
+    .min(1, "Title is required"),
+  description: z
+    .union([
+      z.string({ invalid_type_error: "Description must be a string" }),
+      z.null(),
+      z.undefined(),
+    ])
+    .transform((val) => (val == null ? undefined : val)),
+  techStack: z
+    .array(z.string().trim().min(1, "Tech stack entries cannot be empty"))
+    .optional()
+    .default([]),
+  teamLead: z
+    .string({ required_error: "Team lead is required" })
+    .trim()
+    .min(1, "Team lead is required"),
+  members: z
+    .array(z.string().trim().min(1, "Member id cannot be empty"))
+    .optional()
+    .default([]),
+  company: z
+    .string({ required_error: "Company is required" })
+    .trim()
+    .min(1, "Company is required"),
+  startTime: z.date().optional(),
+  estimatedTimeMinutes: z
+    .number({ invalid_type_error: "Estimated time must be a number" })
+    .int("Estimated time must be an integer")
+    .min(0, "Estimated time cannot be negative")
+    .optional()
+    .default(0),
+});
+
+module.exports = { projectSchema };


### PR DESCRIPTION
## Summary
- add a shared Zod schema for announcement payload validation on the API
- wire the admin and employee announcement forms to react-hook-form with Zod-powered client validation and inline errors
- register the new form-validation dependencies in the web workspace package manifest
- restore the shared Zod schemas for projects and expenses so the API can boot again

## Testing
- npm run build -w apps/api
- npm run build -w apps/web *(fails: missing react-hook-form and @hookform/resolvers packages are not available in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d22906cdf8832b84eee0e2cd082ce6